### PR TITLE
Fix pytest action triggers

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -1,7 +1,16 @@
+name: pytest
+
 on:
-    push:
-    pull_request_target:
-        types: [opened, synchronize, reopened]
+  # Triggers the workflow on push events
+  push:
+    branches: [ 'main' ]
+    tags-ignore: [ '**' ]
+
+  # Triggers the workflow on pull request events
+  pull_request:
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 jobs:
     pylint:


### PR DESCRIPTION
Fixed the triggers in the `pytest.yaml` action such that it may run in the following circumstances:
* push to `main`.
* Changes to a pull request.
* Manually triggered.