### PR TITLE
Don't run repository sync on branch deletion.

### DIFF
--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -10,9 +10,6 @@ on:
     tags:
     - '**'
  
-  # Trigger the workflow when a branch or tag is deleted
-  delete: ~
- 
 jobs:
  
   # Calls a reusable CI workflow to sync the current with a remote repository.


### PR DESCRIPTION
Fixed an issue with the `sync` action that propagates changes from Github to Bitbucket. The problem was that 

- only pushes to the `main` branch were propagated to Bitbucket.
- deleting _any_ branch in Github also triggered a corresponding branch-delete in Bitbucket.

So when a non-`main` branch was created in Github, it was not replicated in Bitbucket (only the `main` branch). When such a branch was deleted in Github, the `sync` action tried to delete it in Bitbucket as well, where it didn't exist, causing an error.

I've fixed this by disabling the `delete` trigger in the `sync.yml` action. As we only want to keep `main` in sync (and won't delete this branch at any point), the `delete` sync isn't necessary.

The alternative would be to sync _all_ branches to Bitbucket, even short-lived branches for pull-requests.