### PR TITLE
Python 3.12+ compatibility and add code coverage to pytest

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -13,29 +13,59 @@ on:
   workflow_dispatch:
 
 jobs:
-    pylint:
-        runs-on: ubuntu-latest
+  pylint:
+    runs-on: ubuntu-latest
 
-        steps:
-          - uses: actions/checkout@v4
+    steps:
+      - uses: actions/checkout@v4
 
-          - name: Set up Python 3.11
-            uses: actions/setup-python@v5
-            with:
-              python-version: '3.11'
-
-          - name: Install pylint
-            run:  | 
-              python -m pip install --upgrade pip
-              python -m pip install -e '.[tests]'
-
-          - name: Code check
-            run:  pylint --rcfile=.pylintrc --output-format=parseable:pylint.log,text tests ifsbench scripts
-
-    pytest:
-        strategy:
-            matrix:
-                python-version: ['3.8', '3.9', '3.10', '3.11']
-        uses: ecmwf-actions/reusable-workflows/.github/workflows/qa-pytest-pyproject.yml@v2
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
         with:
-            python-version: ${{ matrix.python-version }}
+          python-version: '3.11'
+
+      - name: Install pylint
+        run:  |
+          python -m pip install --upgrade pip
+          python -m pip install -e .[tests]
+
+      - name: Code check
+        run:  pylint --rcfile=.pylintrc --output-format=parseable:pylint.log,text tests ifsbench scripts
+
+  pytest:
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: ['ubuntu-latest']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+
+        include:
+          - platform: 'macos-latest'
+            python-version: '3.11'
+
+    name: Run pytest with Python ${{ matrix.python-version }} on ${{ matrix.platform }}
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .[tests]
+
+      - name: Run pytest
+        run: |
+          pytest --cov --cov-report=xml
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # IFSBench - A pythonic benchmarking package for IFS development
 
+[![license](https://img.shields.io/github/license/ecmwf-ifs/ifsbench)](https://www.apache.org/licenses/LICENSE-2.0.html)
+[![pytest](https://github.com/ecmwf-ifs/ifsbench/actions/workflows/pytest.yaml/badge.svg)](https://github.com/ecmwf-ifs/ifsbench/actions/workflows/pytest.yaml)
+[![codecov](https://codecov.io/github/ecmwf-ifs/ifsbench/graph/badge.svg?token=K0617536LF)](https://codecov.io/github/ecmwf-ifs/ifsbench)
+
 **NOTE**: _This is work-in-progress and represents a prototype, not a full solution!_
 
 IFSBench is a prototype tool that aims to provide Python-based
@@ -30,8 +34,8 @@ Johannes Bulin (johannes.bulin@ecmwf.int)
 
 ## Licence
 
-License: [Apache License 2.0](LICENSE) In applying this licence, ECMWF does not waive the privileges and immunities 
-granted to it by virtue of its status as an intergovernmental organisation nor does it submit to any jurisdiction.  
+License: [Apache License 2.0](LICENSE) In applying this licence, ECMWF does not waive the privileges and immunities
+granted to it by virtue of its status as an intergovernmental organisation nor does it submit to any jurisdiction.
 
 ## Contributing
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,18 @@
+codecov:
+  require_ci_to_pass: yes
+  notify:
+    wait_for_ci: yes
+
+coverage:
+  precision: 2
+  round: down
+
+  status:
+    project:
+      default:
+        enabled: yes
+        target: auto
+        threshold: 0.1
+    patch:
+      default:
+        enabled: off

--- a/ifsbench/__init__.py
+++ b/ifsbench/__init__.py
@@ -11,7 +11,7 @@ ifsbench: IFS benchmark and testing utilities in Python
 This package contains Python utilities to run and benchmark the IFS.
 """
 
-from pkg_resources import get_distribution, DistributionNotFound
+from importlib.metadata import version, PackageNotFoundError
 
 from .arch import * # noqa
 from .benchmark import * # noqa
@@ -31,7 +31,7 @@ from .runrecord import * # noqa
 from .util import * # noqa
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    __version__ = version("ifsbench")
+except PackageNotFoundError:
     # package is not installed
     pass


### PR DESCRIPTION
I replaced the use of pkg_resources with importlib for compatibility with Python 3.12+. This is backward compatible until 3.8, which we require as a minimum already.

I've also adapted the pytest plan to include code coverage and upload this to codecov. Unfortunately, there was no easy way to hook this into the reusable workflow, but given the very few extra lines needed for equivalent functionality, it seemed easiest to do it this way.