### PR TITLE
Fixed coverage testing (checks source now, instead of tests)

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Run pytest
         run: |
-          pytest --cov --cov-report=xml
+          python -m pytest --cov=ifsbench --cov-report=xml
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
At the moment, coverage testing tests the coverage of the lines in the tests directory. This is of course not what we want - we want to check the coverage in the actual source directory (ifsbench). I've done two things:

Run python -m pytest instead of pytest. This automatically adds the current path to sys and will therefore use the actual source folder and not whatever we've installed to the virtual environment. If we don't do this, the coverage is always 0%.
I've replaced --cov by --cov=ifsbench so only the ifsbench dir is treated as source.