### PR TITLE
Don't run sync task on forks

### DIFF
--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -15,6 +15,7 @@ jobs:
   # Calls a reusable CI workflow to sync the current with a remote repository.
   #   It will correctly handle addition of any new and removal of existing Git objects.
   sync:
+    if: github.repository == 'ecmwf-ifs/ifsbench'
     name: sync
     uses: ecmwf-actions/reusable-workflows/.github/workflows/sync.yml@v2
     secrets:


### PR DESCRIPTION
At the moment, the `sync` action is run even in forks - which shouldn't be the case and causes unexpected errors. I've added a condition to this action to run only in the main repository.