### PR TITLE
Launching an executable now returns stdout, stderr and return code.

### DIFF
--- a/ifsbench/benchmark.py
+++ b/ifsbench/benchmark.py
@@ -151,7 +151,7 @@ class Benchmark:
         arch: Optional[Arch] = None,
         launcher: Optional[Launcher] = None,
         launcher_flags: Optional[List[str]] = None
-    ):
+    ) -> BenchmarkSummary:
         """
         Run the benchmark.
 
@@ -171,7 +171,8 @@ class Benchmark:
         Returns
         -------
         BenchmarkSummary:
-
+            BenchmarkSummary object that holds the output and the walltime
+            of the benchmark.
         """
 
         env_pipeline = DefaultEnvPipeline(handlers=self.science.env_handlers, env_initial=os.environ)

--- a/ifsbench/benchmark.py
+++ b/ifsbench/benchmark.py
@@ -12,10 +12,12 @@ Generic benchmark implementation.
 from dataclasses import dataclass, field
 import os
 from pathlib import Path
+from time import time
 from typing import List, Optional
 
 from ifsbench.application import Application
 from ifsbench.arch import Arch
+from ifsbench.config_mixin import PydanticConfigMixin
 from ifsbench.data import DataHandler
 from ifsbench.env import EnvHandler, DefaultEnvPipeline
 from ifsbench.job import Job
@@ -29,7 +31,7 @@ class ScienceSetup:
     """
     Generic (scientific) benchmark setup.
 
-    This dataclass encapsulates the information that is needed to describe a 
+    This dataclass encapsulates the information that is needed to describe a
     benchmark:
       * The application that is benchmarked (unless overriden by :class:`TechSetup`).
       * The data pipeline.
@@ -58,8 +60,8 @@ class TechSetup:
     """
     Additional technical details for benchmarks.
 
-    This dataclass can be used in combination with a :class:`ScienceSetup` 
-    to setup a `Benchmark`. It encapsulates additional technical details 
+    This dataclass can be used in combination with a :class:`ScienceSetup`
+    to setup a `Benchmark`. It encapsulates additional technical details
     like debug flags, debug executables or performance-altering environment variables
     that do not change the results of the benchmark.
     """
@@ -76,6 +78,20 @@ class TechSetup:
 
     #: Environment handlers that are used for the initial data setup.
     env_handlers:  List[EnvHandler] = field(default_factory=list)
+
+class BenchmarkSummary(PydanticConfigMixin):
+    """
+    Summary of a benchmark run.
+    """
+
+    #: The standard output of the actual execution.
+    stdout: str
+
+    #: The standard error of the actual execution.
+    stderr: str
+
+    #: The walltime of the actual execution in seconds.
+    walltime: float
 
 @dataclass
 class Benchmark:
@@ -151,6 +167,11 @@ class Benchmark:
             A custom launcher to use. If None, the arch launcher is used.
         launcher_flags: list[str]
             Additional flags to be added to the launcher invocation.
+
+        Returns
+        -------
+        BenchmarkSummary:
+
         """
 
         env_pipeline = DefaultEnvPipeline(handlers=self.science.env_handlers, env_initial=os.environ)
@@ -191,4 +212,16 @@ class Benchmark:
         env_pipeline.add(application.get_env_handlers(run_dir, job))
 
         launch = launcher.prepare(run_dir, job, cmd, library_paths, env_pipeline, launcher_flags)
-        launch.launch()
+
+        start = time()
+        result = launch.launch()
+        elapsed = time() - start
+
+        if result.exit_code != 0:
+            raise RuntimeError("Launching the executable failed!")
+
+        return BenchmarkSummary(
+            stdout=result.stdout,
+            stderr=result.stderr,
+            walltime=elapsed
+        )

--- a/ifsbench/launch/launcher.py
+++ b/ifsbench/launch/launcher.py
@@ -44,6 +44,11 @@ class LaunchData:
     def launch(self):
         """
         Launch the actual executable.
+
+        Returns
+        -------
+        ifsbench.ExecuteResult:
+            The results of the execution.
         """
 
         info(f"Launch command {self.cmd} in {self.run_dir}.")
@@ -52,7 +57,11 @@ class LaunchData:
         for key, value in self.env.items():
             debug(f"\t{key}={value}")
 
-        execute(command=self.cmd, cwd=self.run_dir, env=self.env)
+        return execute(
+            command=self.cmd,
+            cwd=self.run_dir,
+            env=self.env,
+        )
 
 
 class Launcher(ABC):

--- a/ifsbench/launch/launcher.py
+++ b/ifsbench/launch/launcher.py
@@ -16,7 +16,7 @@ from typing import List, Optional
 from ifsbench.job import Job
 from ifsbench.env import EnvPipeline
 from ifsbench.logging import debug, info
-from ifsbench.util import execute
+from ifsbench.util import execute, ExecuteResult
 
 __all__ = ['LaunchData', 'Launcher']
 
@@ -41,7 +41,7 @@ class LaunchData:
     cmd: List[str]
     env: dict = field(default_factory=dict)
 
-    def launch(self):
+    def launch(self) -> ExecuteResult:
         """
         Launch the actual executable.
 

--- a/ifsbench/tests/test_util.py
+++ b/ifsbench/tests/test_util.py
@@ -9,9 +9,8 @@
 Tests for utility routines
 """
 from pathlib import Path
-from subprocess import CalledProcessError
+import sys
 import tempfile
-import pytest
 
 from ifsbench.util import execute
 
@@ -21,15 +20,15 @@ def test_execute():
     Test some aspects of the execute() utility.
     """
     # Very trivial executables with success/error exit codes
-    execute('true')
-    with pytest.raises(CalledProcessError):
-        execute('false')
+    assert execute('true').exit_code == 0
+    assert execute('false').exit_code == 1
 
     with tempfile.TemporaryDirectory(prefix='ifsbench') as tmp_dir:
         # basic logfile capture validation
         logfile = Path(tmp_dir)/'test_execute.log'
-        execute(['echo', 'foo', 'bar'], logfile=logfile)
+        result = execute(['echo', 'foo', 'bar'], logfile=logfile)
         assert logfile.read_text() == 'foo bar\n'
+        assert result.stdout == 'foo bar\n'
 
         # verify env
         execute(['env'], logfile=logfile, env={'FOO': 'bar', 'BAR': 'foo'})
@@ -46,3 +45,9 @@ def test_execute():
         text = 'abc\n' * 100
         execute(['echo', text], logfile=logfile)
         assert logfile.read_text() == text + '\n'
+
+        # Write to stderr
+        result = execute([sys.executable, '-c', 'import sys; print(\'foo bar\', file=sys.stderr)'], logfile=logfile)
+        assert logfile.read_text() == 'foo bar\n'
+        assert result.stdout == ''
+        assert result.stderr == 'foo bar\n'

--- a/ifsbench/tests/test_util.py
+++ b/ifsbench/tests/test_util.py
@@ -51,3 +51,18 @@ def test_execute():
         assert logfile.read_text() == 'foo bar\n'
         assert result.stdout == ''
         assert result.stderr == 'foo bar\n'
+
+def test_execute_dryrun():
+    """
+    Test the execute function in dryrun mode..
+    """
+    # Very trivial executables with success/error exit codes
+    assert execute('true', dryrun=True).exit_code == 0
+    assert execute('false', dryrun=True).exit_code == 0
+
+    with tempfile.TemporaryDirectory(prefix='ifsbench') as tmp_dir:
+        # basic logfile capture validation
+        logfile = Path(tmp_dir)/'test_execute.log'
+        result = execute(['echo', 'foo', 'bar'], dryrun=True, logfile=logfile)
+        assert not logfile.exists()
+        assert result.stdout == ''

--- a/ifsbench/util.py
+++ b/ifsbench/util.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from pprint import pformat
 from subprocess import Popen, PIPE
 import sys
-from typing import List
+from typing import List, Tuple
 
 from ifsbench.logging import debug, info
 
@@ -101,9 +101,12 @@ def execute(command: List[str], **kwargs) -> ExecuteResult:
     stdout = ""
     stderr = ""
 
-    def _read_and_multiplex(p, stdout, stderr):
+    def _read_and_multiplex(p: Popen, stdout: str, stderr: str) -> Tuple[str, str]:
         """
-        Read from ``p.stdout.read()`` and write to log and sys.stdout.
+        Read from ``p.stdout.read()`` and ``p.stderr.read()`` and
+          * forward it to sys.stdout/sys.stderr.
+          * add it to the stdout/stderr strings and return the updated values.
+          * (Optional) write it to the logfile.
         """
         line = p.stdout.read()
         if line:

--- a/ifsbench/util.py
+++ b/ifsbench/util.py
@@ -8,17 +8,32 @@
 """
 Collection of utility routines
 """
+from dataclasses import dataclass
 from os import environ, getcwd
 from pathlib import Path
 from pprint import pformat
-from subprocess import Popen, STDOUT, PIPE, CalledProcessError
+from subprocess import Popen, PIPE
 import sys
 
-from ifsbench.logging import debug, info, error
+from ifsbench.logging import debug, info
 
 
-__all__ = ['execute', 'auto_post_mortem_debugger']
+__all__ = ['ExecuteResult', 'execute', 'auto_post_mortem_debugger']
 
+@dataclass
+class ExecuteResult:
+    """
+    Results of an :func:`execute` invocation.
+    """
+
+    #: The captured standard output.
+    stdout: str
+
+    #: The captured standard error.
+    stderr: str
+
+    #: The return code of the execution.
+    exit_code: int
 
 def execute(command, **kwargs):
     """
@@ -34,11 +49,11 @@ def execute(command, **kwargs):
         Do not actually run the command but log it (default: `False`).
     logfile : str, optional
         Write stdout to this file (default: `None`).
-    stdout : optional
-        Overwrite `stdout` attribute of :any:`subprocess.run`. Ignored if
-        :attr:`logfile` is given (default: `None`).
-    stderr : optional
-        Overwrite `stderr` attribute of :any:`subprocess.run` (default: `None`).
+
+    Returns
+    -------
+    ExecuteResult:
+        The results of the execution (stdout, stderr, exit code)
     """
     cwd = kwargs.pop('cwd', None)
     env = kwargs.pop('env', None)
@@ -57,8 +72,6 @@ def execute(command, **kwargs):
     else:
         run_env = None
 
-    stdout = kwargs.pop('stdout', None)
-    stderr = kwargs.pop('stderr', STDOUT)
 
     # Log the command we're about to execute
     cwd = getcwd() if cwd is None else str(cwd)
@@ -68,60 +81,78 @@ def execute(command, **kwargs):
     if dryrun:
         # Only print the environment when in dryrun mode.
         info('[ifsbench] Environment: ' + str(run_env))
-        return
+        return ExecuteResult(
+            stdout="",
+            stderr="",
+            exit_code=0
+        )
 
     cmd_args = {
-        'cwd': cwd, 'env': run_env, 'text': True, 'stderr': stderr
+        'cwd': cwd, 'env': run_env, 'text': True, 'stdout': PIPE, 'stderr': PIPE
     }
 
     if logfile:
         # If we're file-logging, intercept via pipe
         _log_file = Path(logfile).open('w', encoding='utf-8') # pylint: disable=consider-using-with
-        cmd_args['stdout'] = PIPE
     else:
         _log_file = None
-        cmd_args['stdout'] = stdout
 
+    stdout = ""
+    stderr = ""
 
-    def _read_and_multiplex(p):
+    def _read_and_multiplex(p, stdout, stderr):
         """
         Read from ``p.stdout.read()`` and write to log and sys.stdout.
         """
         line = p.stdout.read()
         if line:
+            stdout += line
+
             # Forward to user output
             sys.stdout.write(line)
 
-            # Also flush to logfile
-            _log_file.write(line)
-            _log_file.flush()
+            if logfile:
+                # Also flush to logfile
+                _log_file.write(line)
+                _log_file.flush()
 
+        line = p.stderr.read()
+        if line:
+            stderr += line
+
+            # Forward to user output
+            sys.stderr.write(line)
+
+            if logfile:
+                # Also flush to logfile
+                _log_file.write(line)
+                _log_file.flush()
+
+        return stdout, stderr
+
+    ret = 1
     try:
         # Execute with our args and outside args
         with Popen(command, **cmd_args, **kwargs) as p:
 
-            if logfile:
-                # Intercept p.stdout and multiplex to file and sys.stdout
-                while p.poll() is None:
-                    _read_and_multiplex(p)
+            # Intercept p.stdout and multiplex to file and sys.stdout
+            while p.poll() is None:
+                stdout, stderr = _read_and_multiplex(p, stdout, stderr)
 
             # Check for successful completion
             ret = p.wait()
 
-            if logfile:
-                # Read one last time to catch racy process output
-                _read_and_multiplex(p)
-
-        if ret:
-            raise CalledProcessError(ret, command)
-
-    except CalledProcessError as excinfo:
-        error(f'Execution failed with return code: {excinfo.returncode}')
-        raise excinfo
-
+            # Read one last time to catch racy process output
+            stdout, stderr = _read_and_multiplex(p, stdout, stderr)
     finally:
         if _log_file:
             _log_file.close()
+
+    return ExecuteResult(
+        stdout=stdout,
+        stderr=stderr,
+        exit_code=ret
+    )
 
 def as_tuple(item, dtype=None, length=None):
     """

--- a/ifsbench/util.py
+++ b/ifsbench/util.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from pprint import pformat
 from subprocess import Popen, PIPE
 import sys
+from typing import List
 
 from ifsbench.logging import debug, info
 
@@ -35,7 +36,7 @@ class ExecuteResult:
     #: The return code of the execution.
     exit_code: int
 
-def execute(command, **kwargs):
+def execute(command: List[str], **kwargs) -> ExecuteResult:
     """
     Execute a single command with a given directory or environment.
 

--- a/ifsbench/util.py
+++ b/ifsbench/util.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from pprint import pformat
 from subprocess import Popen, PIPE
 import sys
-from typing import List, Tuple
+from typing import List
 
 from ifsbench.logging import debug, info
 


### PR DESCRIPTION
Updated the actual executable-launch mechanism such that it returns the output (stdout, stderr) from the launch back to Python. Previously it was not possible to catch stdout/stderr during benchmarking