### PR TITLE
Freeze pygrib at older version 

### DIFF
--- a/ifsbench/tests/test_gribfile.py
+++ b/ifsbench/tests/test_gribfile.py
@@ -211,7 +211,7 @@ def test_modify_grib_file(here, tmp_path):
     noise_config = dict.fromkeys(params, uniform_noise)
 
     modify_grib_file(
-        input_path,
+        str(input_path),
         output_path,
         base_modification=no_noise,
         parameter_config=noise_config,
@@ -257,7 +257,7 @@ def test_modify_grib_fractionparam(here, tmp_path):
         noise_param='packingError', noise_scale=noise_scale
     )
 
-    modify_grib_file(input_path, output_path, base_modification=uniform_noise)
+    modify_grib_file(str(input_path), output_path, base_modification=uniform_noise)
 
     # confirm that cc has been modified and clipped to [0,1]
     param = params[0]
@@ -303,7 +303,7 @@ def test_modify_grib_output_exists(here, tmp_path):
         pass
     os.utime(output_path, ns=(1000, 1000))
 
-    modify_grib_file(input_path, output_path, no_noise)
+    modify_grib_file(str(input_path), output_path, no_noise)
 
     # Confirm that file times have not changed and the file is empty,
     # i.e. nothing was written.
@@ -327,7 +327,7 @@ def test_modify_grib_output_exists_allow_overwrite(here, tmp_path):
         pass
     os.utime(output_path, ns=(1000, 1000))
 
-    modify_grib_file(input_path, output_path, no_noise, overwrite_existing=True)
+    modify_grib_file(str(input_path), output_path, no_noise, overwrite_existing=True)
 
     # Confirm that file times have not changed and the file is empty,
     # i.e. nothing was written.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ tests = [
 grib = [
   "cfgrib",
   "eccodes",
-  "pygrib",
+  "pygrib == 2.1.4",
 ]
 
 docs = [


### PR DESCRIPTION
The grib tests have not been run in while since the necessary libraries are not available for automatic testing. When I ran the tests I found one of the 'modify' tests no longer passed.
The problem appears to be a mismatch between pygrib and numpy leading to a segfault with floating point error. The weird part is that part of it runs, and it actually fails in the test when reading the unmodified input file in xarray (using cfgrib engine) for comparison rather than during the modification (which uses pygrib). But if I comment out the modification, xarray+cfgrib can read the file just fine. 
There is a pygrib issue that looks related: https://github.com/jswhit/pygrib/issues/260 but still open. 

Based on the pygrib changelog, we must have been on pygrib 2.1.5 when that code was initially developed. If I install that version and numpy 1.26.4 (current is 2.2.4), the tests pass; any numpy 2.x seems to fail. 
If I use pygrib 2.1.4 it runs with minor fixes (cast Path to str) with current numpy. pygrib 2.1.6 supposedly adds numpy 2 support (https://github.com/jswhit/pygrib/blob/master/Changelog), but I have not been able to find a version that actually works. 
I have also randomly tried an older cfgrib version, but no luck. 

Given that numpy is more important than pygrib/cfgrib for the rest of the code, I'm freezing pygrib at 2.1.4 to get the code to run.

I will try to remember to check at some later time if the pygrib issue is fixed.