### PR TITLE
Fix subclass resolution when deserialising (#40).

### DIFF
--- a/ifsbench/data/datahandler.py
+++ b/ifsbench/data/datahandler.py
@@ -6,9 +6,13 @@
 # nor does it submit to any jurisdiction.
 
 from abc import abstractmethod
-from typing import Union
-
 from pathlib import Path
+
+from typing import Any, ClassVar, Dict, Type, Union
+
+from pydantic import model_validator, TypeAdapter, Field
+from pydantic_core.core_schema import ValidatorFunctionWrapHandler
+from typing_extensions import Annotated
 
 from ifsbench.config_mixin import PydanticConfigMixin
 
@@ -27,6 +31,28 @@ class DataHandler(PydanticConfigMixin):
     # handler_type is used to distinguish DataHandler subclasses and has
     # to be defined for any subclass.
     handler_type: str
+
+    _subclasses: ClassVar[Dict[str, Type[Any]]] = {}
+    _discriminating_type_adapter: ClassVar[TypeAdapter]
+
+    @model_validator(mode='wrap')
+    @classmethod
+    def _parse_into_subclass(
+        cls, v: Any, handler: ValidatorFunctionWrapHandler
+    ) -> 'DataHandler':
+        if cls is DataHandler:
+            return DataHandler._discriminating_type_adapter.validate_python(v)
+        return handler(v)
+
+    @classmethod
+    def __pydantic_init_subclass__(cls, **kwargs):
+        DataHandler._subclasses[cls.model_fields['handler_type'].default] = cls
+        DataHandler._discriminating_type_adapter = TypeAdapter(
+            Annotated[
+                Union[tuple(DataHandler._subclasses.values())],
+                Field(discriminator='handler_type'),
+            ]
+        )
 
     @abstractmethod
     def execute(self, wdir: Union[str, Path], **kwargs):

--- a/ifsbench/data/extracthandler.py
+++ b/ifsbench/data/extracthandler.py
@@ -9,7 +9,6 @@ import pathlib
 import shutil
 from typing import Dict, Optional, Union
 
-from pydantic import Field
 from typing_extensions import Literal
 
 from ifsbench.data.datahandler import DataHandler
@@ -35,7 +34,7 @@ class ExtractHandler(DataHandler):
         :meth:`execute`.
     """
 
-    handler_type: Literal['ExtractHandler'] = Field(default='ExtractHandler')
+    handler_type: Literal['ExtractHandler'] = 'ExtractHandler'
     archive_path: str
     target_dir: Optional[str] = None
 

--- a/ifsbench/data/fetchhandler.py
+++ b/ifsbench/data/fetchhandler.py
@@ -11,8 +11,6 @@ import shutil
 import urllib.error
 import urllib.request
 
-from pydantic import Field
-
 from ifsbench.data.datahandler import DataHandler
 from ifsbench.logging import debug, info, warning
 
@@ -24,7 +22,7 @@ class FetchHandler(DataHandler):
     """
 
     #: Identifier for the DataHandler type.
-    handler_type: Literal['FetchHandler'] = Field(default='FetchHandler')
+    handler_type: Literal['FetchHandler'] = 'FetchHandler'
 
     #: The source URL from where the file gets fetched.
     source_url: str

--- a/ifsbench/data/namelisthandler.py
+++ b/ifsbench/data/namelisthandler.py
@@ -9,7 +9,7 @@ from enum import Enum
 import pathlib
 from typing import Any, Dict, List, Union
 
-from pydantic import Field, model_validator
+from pydantic import model_validator
 from typing_extensions import Literal, Self
 
 import f90nml
@@ -138,7 +138,7 @@ class NamelistHandler(DataHandler):
         The NamelistOverrides that will be applied.
     """
 
-    handler_type: Literal['NamelistHandler'] = Field(default='NamelistHandler')
+    handler_type: Literal['NamelistHandler'] = 'NamelistHandler'
     input_path: pathlib.Path
     output_path: pathlib.Path
     overrides: List[Dict[str, Union[str, int]]]

--- a/ifsbench/data/renamehandler.py
+++ b/ifsbench/data/renamehandler.py
@@ -12,7 +12,7 @@ import re
 import shutil
 from typing import Union
 
-from pydantic import computed_field, Field
+from pydantic import computed_field
 from typing_extensions import Literal
 
 from ifsbench.data.datahandler import DataHandler
@@ -54,7 +54,7 @@ class RenameHandler(DataHandler):
         Specifies how the renaming is done (copy, move, symlink).
     """
 
-    handler_type: Literal['RenameHandler'] = Field(default='RenameHandler')
+    handler_type: Literal['RenameHandler'] = 'RenameHandler'
     pattern: str
     repl: str
     mode: RenameMode = RenameMode.SYMLINK

--- a/ifsbench/launch/mpirunlauncher.py
+++ b/ifsbench/launch/mpirunlauncher.py
@@ -8,7 +8,6 @@
 from pathlib import Path
 from typing import List, Optional
 
-from pydantic import Field
 from typing_extensions import Literal
 
 from ifsbench.env import DefaultEnvPipeline, EnvOperation, EnvPipeline, EnvHandler
@@ -22,7 +21,7 @@ class MpirunLauncher(Launcher):
     :any:`Launcher` implementation for a standard mpirun
     """
 
-    launcher_type: Literal['MpirunLauncher'] = Field(default='MpirunLauncher')
+    launcher_type: Literal['MpirunLauncher'] = 'MpirunLauncher'
 
     _job_options_map = {
         'tasks': '--n={}',

--- a/ifsbench/launch/srunlauncher.py
+++ b/ifsbench/launch/srunlauncher.py
@@ -8,7 +8,6 @@
 from pathlib import Path
 from typing import List, Optional
 
-from pydantic import Field
 from typing_extensions import Literal
 
 from ifsbench.env import DefaultEnvPipeline, EnvOperation, EnvPipeline, EnvHandler
@@ -22,7 +21,7 @@ class SrunLauncher(Launcher):
     :any:`Launcher` implementation for Slurm's srun.
     """
 
-    launcher_type: Literal['SrunLauncher'] = Field(default='SrunLauncher')
+    launcher_type: Literal['SrunLauncher'] = 'SrunLauncher'
 
     _job_options_map = {
         'nodes': '--nodes={}',

--- a/ifsbench/tests/test_arch.py
+++ b/ifsbench/tests/test_arch.py
@@ -31,7 +31,7 @@ _cpu_config_2 = CpuConfiguration(
 
 @pytest.mark.parametrize('arch_in, job_in, job_out, launcher_out', [
     (
-        {'launcher': SrunLauncher(), 'cpu_config': _cpu_config_1, 'set_explicit': False},
+        {'launcher': {'launcher_type': 'SrunLauncher'}, 'cpu_config': _cpu_config_1, 'set_explicit': False},
         {'tasks': 64, 'cpus_per_task': 4, 'threads_per_core': 1},
         {'tasks': 64, 'cpus_per_task': 4, 'threads_per_core': 1},
         SrunLauncher()

--- a/ifsbench/tests/test_benchmark.py
+++ b/ifsbench/tests/test_benchmark.py
@@ -13,7 +13,6 @@ from pathlib import Path
 from time import sleep
 import sys
 
-from pydantic import Field
 import pytest
 from typing_extensions import Literal
 
@@ -39,7 +38,7 @@ def fixture_test_setup_files():
     ]
 
     class TouchHandler(DataHandler):
-        handler_type: Literal['TouchHandler'] = Field(default='TouchHandler')
+        handler_type: Literal['TouchHandler'] = 'TouchHandler'
         path: str
 
         def execute(self, wdir, **kwargs):
@@ -143,7 +142,7 @@ class _DummyLauncher(Launcher):
     Dummy launcher that just calls the given executable.
     """
 
-    launcher_type: Literal['Dummy'] = Field(default='Dummy')
+    launcher_type: Literal['Dummy'] = 'Dummy'
 
     _prepare_called = False
 
@@ -178,7 +177,7 @@ def test_defaultbenchmark_run(
     arch = (
         DefaultArch.from_config(
             {
-                'launcher': _DummyLauncher.from_config({'launcher_type': 'Dummy'}),
+                'launcher': {'launcher_type': 'Dummy'},
                 'cpu_config': CpuConfiguration(),
             }
         )


### PR DESCRIPTION
Found on https://github.com/pydantic/pydantic/issues/7366#issuecomment-1711827295
This should finally allow subclassing with serialisation and deserialisation and adding subclasses at runtime that can be used as their base type in other pydantic classes.

Also clean up redundant Field(default='xyz') statements in Launcher and DataHandler subclasses.