### PR TITLE
Fix for pandas.DataFrame serialisation for YAML

### DIFF
--- a/ifsbench/tests/test_pydantic_dataframe.py
+++ b/ifsbench/tests/test_pydantic_dataframe.py
@@ -12,7 +12,7 @@ Check the PydandictDataFrame type.
 import json
 from typing import Dict, List
 
-from pandas import DataFrame
+from pandas import DataFrame, MultiIndex
 import pytest
 import yaml
 
@@ -70,6 +70,41 @@ def test_pydantic_data_to_config():
             'columns': ['mean', 'max', 'min'], 
             'data': [[2.0, 3.0, 1.0]], 
             'index_names': [None], 
+            'column_names': [None]
+        }
+    }
+
+    assert config == ref
+
+def test_pydantic_data_to_config_multiindex():
+    """
+    Serialise PydanticFrame objects and check the serialisation output.
+    """
+
+    class _DummyClass(PydanticConfigMixin):
+        frame: PydanticDataFrame
+
+    index = MultiIndex.from_tuples([
+            ('min', 'soil stuff'),
+            ('mean', 'soil stuff'),
+            ('min', 'water stuff'),
+            ('mean', 'water stuff')
+        ],
+        names=['stat', 'type']
+    )
+
+    frame=DataFrame([[2.0, 3.0, 1.0], [4.0, -2.0, 1.0], [0.0, 0.0, 5.0], [2.0, 3.0, 4.0]],
+                    index=index, columns=['mean', 'max', 'min'])
+
+    obj = _DummyClass(frame=frame)
+
+    config = obj.dump_config()
+    ref = {'frame': {
+            'index': [['min', 'soil stuff'], ['mean', 'soil stuff'], 
+                      ['min', 'water stuff'], ['mean', 'water stuff']],
+            'columns': ['mean', 'max', 'min'], 
+            'data': [[2.0, 3.0, 1.0], [4.0, -2.0, 1.0], [0.0, 0.0, 5.0], [2.0, 3.0, 4.0]], 
+            'index_names': ['stat', 'type'],
             'column_names': [None]
         }
     }


### PR DESCRIPTION
When serialising a `pandas.DataFrame` object (see #44) with a multi-index, the resulting dictionary contained `tuple` objects which aren't natively supported in YAML. So when dumping such a dictionary to a YAML file we got stuff like this:
```
    index:
    - !!python/tuple
      - min
      - 1
      - 1
      - 1
      - 1
```
I've made sure that during serialisation, all tuples are converted to lists first, to avoid this problem.