### PR TITLE
Removed obsolete from_config functions from some data handler classes.

### DIFF
--- a/ifsbench/data/extracthandler.py
+++ b/ifsbench/data/extracthandler.py
@@ -7,7 +7,7 @@
 
 import pathlib
 import shutil
-from typing import Dict, Optional, Union
+from typing import Optional, Union
 
 from typing_extensions import Literal
 
@@ -35,28 +35,18 @@ class ExtractHandler(DataHandler):
     """
 
     handler_type: Literal['ExtractHandler'] = 'ExtractHandler'
-    archive_path: str
-    target_dir: Optional[str] = None
-
-    @classmethod
-    def from_config(cls, config: Dict[str, Optional[str]]) -> 'ExtractHandler':
-        eh = cls(**config)
-        eh._archive_path = pathlib.Path(eh.archive_path)
-        if eh.target_dir is None:
-            eh._target_dir = None
-        else:
-            eh._target_dir = pathlib.Path(eh.target_dir)
-        return eh
+    archive_path: pathlib.Path
+    target_dir: Optional[pathlib.Path] = None
 
     def execute(self, wdir: Union[str, pathlib.Path], **kwargs) -> None:
         wdir = pathlib.Path(wdir)
 
         target_dir = wdir
-        if self._target_dir is not None:
-            if self._target_dir.is_absolute():
-                target_dir = self._target_dir
+        if self.target_dir is not None:
+            if self.target_dir.is_absolute():
+                target_dir = self.target_dir
             else:
-                target_dir = wdir / self._target_dir
+                target_dir = wdir / self.target_dir
 
-        debug(f"Unpack archive {self._archive_path} to {target_dir}.")
-        shutil.unpack_archive(self._archive_path, target_dir)
+        debug(f"Unpack archive {str(self.archive_path)} to {str(target_dir)}.")
+        shutil.unpack_archive(self.archive_path, target_dir)

--- a/ifsbench/tests/test_config_utils.py
+++ b/ifsbench/tests/test_config_utils.py
@@ -64,16 +64,16 @@ def test_read_yaml_config(tmp_path: pathlib.Path):
     # Check some sample objects for correctness.
     ext_handler = run_conf['ext_handler']
     assert isinstance(ext_handler, ExtractHandler)
-    assert ext_handler.archive_path == 'big_tarball.tar.gz'
+    assert ext_handler.archive_path == pathlib.Path('big_tarball.tar.gz')
 
     nml_handler = run_conf['nml_handler']
     assert isinstance(nml_handler, NamelistHandler)
     assert len(nml_handler.overrides) == 3
-    assert isinstance(nml_handler._overrides[0], NamelistOverride)
-    no = nml_handler._overrides[0]
+    assert isinstance(nml_handler.overrides[0], NamelistOverride)
+    no = nml_handler.overrides[0]
     assert no.mode == NamelistOperation.SET
     assert no.value == 16
-    no = nml_handler._overrides[2]
+    no = nml_handler.overrides[2]
     assert no.mode == NamelistOperation.DELETE
     assert no.value is None
 


### PR DESCRIPTION
Some of the `DataHandler` subclasses had explicit `from_config` functions to initialise them as well as attributes of Dict type (instead of the actual datatype). This is probably a relict from earlier serialisation attempts. I've removed the explicit `from_config` functions and have adapted the data types.
This is necessary to make things work smoothly in `ecLand` (and probably everywhere else). Tests are fine but please tell me if this breaks anything.