### PR TITLE
DataFrame-related fixes

### DIFF
--- a/ifsbench/validation/frame_close_validation.py
+++ b/ifsbench/validation/frame_close_validation.py
@@ -68,10 +68,8 @@ class FrameCloseValidation:
 
         close = numpy.isclose(frame1.values, frame2.values, rtol=self.rtol, atol=self.atol, equal_nan=True)
 
-        # Do some dataframe black magic to convert close (bool array which is True
-        # wherever the two frames are close) into a list of (index, column) tuples.
-        close_frame = DataFrame(data=~close, index=frame1.index, columns=frame1.columns)
-        mismatch = close_frame.where(close_frame).stack().index.to_list()
+        mismatch = numpy.argwhere(~close)
+        mismatch = [(frame1.index[i], frame1.columns[j]) for i,j in mismatch]
 
         return numpy.all(close), mismatch
         

--- a/ifsbench/validation/tests/test_frame_close_validation.py
+++ b/ifsbench/validation/tests/test_frame_close_validation.py
@@ -45,7 +45,7 @@ def test_frameclose_equal_self(atol, rtol, test_frames):
 ])
 def test_frameclose_unequal_self_noise(atol, rtol, add_noise, test_frames):
     """
-    Verify that a frame is not equal to a perturbed copy of itself if the 
+    Verify that a frame is not equal to a perturbed copy of itself if the
     applied noise is larger than the tolerances.
     """
     validation = FrameCloseValidation(atol=atol, rtol=rtol)
@@ -61,12 +61,13 @@ def test_frameclose_unequal_self_noise(atol, rtol, add_noise, test_frames):
 
         assert mismatch == mismatch_ref
 
-
-def test_frameclose_explicit():
+@pytest.mark.parametrize('atol', [0, 1e-8, 1e-4])
+@pytest.mark.parametrize('rtol', [0, 1e-8, 1e-4])
+def test_frameclose_explicit_mismatch(atol, rtol):
     """
     Some handcoded result checking for FrameCloseValidation.
     """
-    validation = FrameCloseValidation(atol=0, rtol=0)
+    validation = FrameCloseValidation(atol=atol, rtol=rtol)
 
     frame1 = DataFrame([[2.0, 3.0, 4], [5.0, 1.0, 3]], index=['Step 0', 'Step 1'])
     frame2 = DataFrame([[2.0, 3.001, 4], [5.0, 1.0, 3]], index=['Step 0', 'Step 1'])
@@ -76,20 +77,36 @@ def test_frameclose_explicit():
     assert not equal
     assert mismatch == [('Step 0', 1)]
 
+@pytest.mark.parametrize('atol', [0, 1e-8, 1e-4])
+@pytest.mark.parametrize('rtol', [0, 1e-8, 1e-4])
+def test_frameclose_explicit_mismatch_dtype(atol, rtol):
+    """
+    Some handcoded result checking for FrameCloseValidation.
+    """
+    validation = FrameCloseValidation(atol=atol, rtol=rtol)
+
+    frame1 = DataFrame([[2.0, 3.0, 4], [5.0, 1.0, 3]], index=['Step 0', 'Step 1'])
+
+    # Last column is treated as int. This shouldn't match frame1 due to this.
     frame2 = DataFrame([[2.0, 3.001, 4.0], [5.0, 1.0, 3]], index=['Step 0', 'Step 1'])
 
     equal, mismatch = validation.compare(frame1, frame2)
 
     assert not equal
+
+    # No mismatch should be given as the general structure of the two frames
+    # (datatypes!) is not equal.
     assert len(mismatch) == 0
 
 
-def test_frame_mismatch_multiindex():
+@pytest.mark.parametrize('atol', [0, 1e-8, 1e-4])
+@pytest.mark.parametrize('rtol', [0, 1e-8, 1e-4])
+def test_frame_mismatch_multiindex(atol, rtol):
     """
     Some handcoded checks for multi-index frames and corresponding mismatch
     return values.
     """
-    validation = FrameCloseValidation(atol=0, rtol=0)
+    validation = FrameCloseValidation(atol=atol, rtol=rtol)
 
     index = MultiIndex.from_tuples([('Step 0', 'type a'), ('Step 0', 'type b')])
 
@@ -102,10 +119,3 @@ def test_frame_mismatch_multiindex():
     assert mismatch == [(('Step 0', 'type a'), 1)]
     assert frame1.loc[mismatch[0][0], mismatch[0][1]] == 3.0
     assert frame2.loc[mismatch[0][0], mismatch[0][1]] == 3.001
-
-    frame2 = DataFrame([[2.0, 3.001, 4.0], [5.0, 1.0, 3]], index=['Step 0', 'Step 1'])
-
-    equal, mismatch = validation.compare(frame1, frame2)
-
-    assert not equal
-    assert len(mismatch) == 0

--- a/ifsbench/validation/tests/test_frame_close_validation.py
+++ b/ifsbench/validation/tests/test_frame_close_validation.py
@@ -11,7 +11,7 @@ Some sanity tests for the :class:`FrameCloseValidation` implementation.
 
 import itertools
 
-from pandas import DataFrame
+from pandas import DataFrame, MultiIndex
 import pytest
 
 from ifsbench.validation.frame_close_validation import FrameCloseValidation
@@ -75,6 +75,33 @@ def test_frameclose_explicit():
 
     assert not equal
     assert mismatch == [('Step 0', 1)]
+
+    frame2 = DataFrame([[2.0, 3.001, 4.0], [5.0, 1.0, 3]], index=['Step 0', 'Step 1'])
+
+    equal, mismatch = validation.compare(frame1, frame2)
+
+    assert not equal
+    assert len(mismatch) == 0
+
+
+def test_frame_mismatch_multiindex():
+    """
+    Some handcoded checks for multi-index frames and corresponding mismatch
+    return values.
+    """
+    validation = FrameCloseValidation(atol=0, rtol=0)
+
+    index = MultiIndex.from_tuples([('Step 0', 'type a'), ('Step 0', 'type b')])
+
+    frame1 = DataFrame([[2.0, 3.0, 4], [5.0, 1.0, 3]], index=index)
+    frame2 = DataFrame([[2.0, 3.001, 4], [5.0, 1.0, 3]], index=index)
+
+    equal, mismatch = validation.compare(frame1, frame2)
+
+    assert not equal
+    assert mismatch == [(('Step 0', 'type a'), 1)]
+    assert frame1.loc[mismatch[0][0], mismatch[0][1]] == 3.0
+    assert frame2.loc[mismatch[0][0], mismatch[0][1]] == 3.001
 
     frame2 = DataFrame([[2.0, 3.001, 4.0], [5.0, 1.0, 3]], index=['Step 0', 'Step 1'])
 


### PR DESCRIPTION
I had to fix two things that were causing issues when using ifsbench in ecLand:

- When serialising a `pandas.DataFrame` that contained `pandas.Timestamp` objects, the `Timestamp` objects were not serialised to a standard Python object (dict/list/int/float/str/None) and therefore caused issues when writing/reading to/from a YAML/JSON file. I've added an explicit conversion from `Timestamp` to `str` when serialising DataFrame objects.
- There was a bug in finding non-matching entries when comparing two `pandas.DataFrame` objects that use multi-indices. Instead of returning a list of `(idx, col)` pairs, the function merged `idx` and `col` into a single tuple, making it impossible to figure out to which row/column the information belonged.