### PR TITLE
Fixed wrong flags when using the MpirunLauncher.

### DIFF
--- a/ifsbench/launch/mpirunlauncher.py
+++ b/ifsbench/launch/mpirunlauncher.py
@@ -24,10 +24,10 @@ class MpirunLauncher(Launcher):
     launcher_type: Literal['MpirunLauncher'] = 'MpirunLauncher'
 
     _job_options_map = {
-        'tasks': '--n={}',
-        'tasks_per_node': '--npernode={}',
-        'tasks_per_socket': '--npersocket={}',
-        'cpus_per_task': '--cpus-per-proc={}',
+        'tasks': '-np {}',
+        'tasks_per_node': '-npernode {}',
+        'tasks_per_socket': '-npersocket {}',
+        'cpus_per_task': '-cpus-per-proc {}',
     }
 
     _bind_options_map = {

--- a/ifsbench/launch/tests/test_mpirunlauncher.py
+++ b/ifsbench/launch/tests/test_mpirunlauncher.py
@@ -120,7 +120,7 @@ def test_mpirunLauncher_prepare_run_dir(
             [],
             'test_env_none',
             [],
-            ['mpirun', '--n=64', '--cpus-per-proc=4', 'ls', '-l'],
+            ['mpirun', '-np 64', '-cpus-per-proc 4', 'ls', '-l'],
         ),
         (
             ['something'],


### PR DESCRIPTION
Apparently, `mpirun` doesn't use double-dashed options like most other tools and doesn't understand `mpirun --n=2` but only `mpirun --n 2`. I've fixed this by switching to single-dash options and removing the `=`.