### PR TITLE
Fixed problem with mpirun flags not being split into separate strings.

### DIFF
--- a/ifsbench/launch/mpirunlauncher.py
+++ b/ifsbench/launch/mpirunlauncher.py
@@ -79,7 +79,10 @@ class MpirunLauncher(Launcher):
             value = getattr(job, attr, None)
 
             if value is not None:
-                flags += [option.format(value)]
+                # Split the resulting split up if it contains spaces. Otherwise
+                # we might end up with a command like ['mpirun', '-n 4', 'program']
+                # which causes errors. We want ['mpirun', '-n', '4', 'program'].
+                flags += option.format(value).split(" ")
 
         if job.bind:
             flags += list(self._bind_options_map[job.bind])

--- a/ifsbench/launch/tests/test_mpirunlauncher.py
+++ b/ifsbench/launch/tests/test_mpirunlauncher.py
@@ -120,7 +120,7 @@ def test_mpirunLauncher_prepare_run_dir(
             [],
             'test_env_none',
             [],
-            ['mpirun', '-n 64', '--cpus-per-proc 4', 'ls', '-l'],
+            ['mpirun', '-n', '64', '--cpus-per-proc', '4', 'ls', '-l'],
         ),
         (
             ['something'],


### PR DESCRIPTION
Unfortunately, #49 introduced new problems with `mpirun`, as flags like `-n 4` were not split up properly, resulting in commands like `['mpirun', '-n 4', 'executable']` being passed to the `subprocess` module.
This caused problems when actually launching the executable.

I've resolved this by splitting up things like `-n 4` into `['-n', '4']` which seems to work properly.