### PR TITLE
[Hotfix] Atos_ac GPU affinity

### DIFF
--- a/ifsbench/arch.py
+++ b/ifsbench/arch.py
@@ -318,23 +318,33 @@ class Atos(Arch):
 
             # To ensure we correctly bind GPUs to CPUs we write a little
             # wrapper script that maps the correct CUDA_VISIBLE_DEVICES
-            # id to each rank locally per node
+            # id to each rank locally per node.
+            # Because the mapping from NUMA domain to GPU is
+            # [1->0, 0->1, 3->2, 2->3], we need to apply some reordering here
 
-            if tasks_per_node <= gpus_per_node:
-                # With less or equal tasks per node than GPUs available,
-                # we can map one GPU to each task, in ascending order
-                # of local rank number per node
-                gpu_mapping_str = '${SLURM_LOCALID}'
-            else:
-                # With more ranks than GPUs available per node,
-                # we map subsequent rank ids on a node to the same
-                # GPU - effectively a compact allocation strategy
-                ranks_per_gpu = (tasks_per_node - 1) // gpus_per_node + 1
-                gpu_mapping_str = f'$((SLURM_LOCALID / {ranks_per_gpu}))'
+            # The GPU that is closest to each core
+            core_to_gpu_mapping = {core: 1 for core in range(32)} | {core: 0 for core in range(32, 64)}
+            core_to_gpu_mapping |= {core: 3 for core in range(64, 96)} | {core: 2 for core in range(96, 128)}
 
+            # Determine the cores that each task is using on a node
+            physical_cpus_per_task = (cpus_per_task - 1) // threads_per_core + 1
+            physical_cores_per_task = {
+                local_rank: [physical_cpus_per_task * local_rank + i for i in range(physical_cpus_per_task)]
+                for local_rank in range(tasks_per_node)
+            }
+
+            # The GPUs to be used by each rank
+            task_gpu_strings = [
+                ','.join(dict.fromkeys(
+                    str(core_to_gpu_mapping[core])
+                    for core in physical_cores_per_task[local_rank]
+                ))
+                for local_rank in range(tasks_per_node)
+            ]
             wrapper_str = f"""
 #!/bin/bash
-export CUDA_VISIBLE_DEVICES={gpu_mapping_str}
+VISIBLE_DEVICES_PER_RANK=({' '.join(task_gpu_strings)})
+export CUDA_VISIBLE_DEVICES=${{VISIBLE_DEVICES_PER_RANK[${{SLURM_LOCALID}}]}}
 exec $*
             """.strip()
 
@@ -355,6 +365,11 @@ exec $*
 
         # Bind to cores
         bind = CpuBinding.BIND_CORES
+
+        if threads_per_core > 1:
+            launch_user_options.insert(0, '--hint=multithread')
+        elif threads_per_core == 1:
+            launch_user_options.insert(0, '--hint=nomultithread')
 
         # Build job description
         job = Job(cls.cpu_config, tasks=tasks, tasks_per_node=tasks_per_node,

--- a/ifsbench/arch.py
+++ b/ifsbench/arch.py
@@ -323,8 +323,10 @@ class Atos(Arch):
             # [1->0, 0->1, 3->2, 2->3], we need to apply some reordering here
 
             # The GPU that is closest to each core
-            core_to_gpu_mapping = {core: 1 for core in range(32)} | {core: 0 for core in range(32, 64)}
-            core_to_gpu_mapping |= {core: 3 for core in range(64, 96)} | {core: 2 for core in range(96, 128)}
+            core_to_gpu_mapping = {core: 1 for core in range(32)}
+            core_to_gpu_mapping.update({core: 0 for core in range(32, 64)})
+            core_to_gpu_mapping.update({core: 3 for core in range(64, 96)})
+            core_to_gpu_mapping.update({core: 2 for core in range(96, 128)})
 
             # Determine the cores that each task is using on a node
             physical_cpus_per_task = (cpus_per_task - 1) // threads_per_core + 1


### PR DESCRIPTION
A small hotfix to #52: Turns out the affinity mapping of CPUs to GPUs is actually not linear on Atos_ac:

```
        GPU0    GPU1    GPU2    GPU3    NIC0    NIC1    CPU Affinity    NUMA Affinity   GPU NUMA ID
GPU0     X      NV4     NV4     NV4     SYS     SYS     32-63,160-191   1               N/A
GPU1    NV4      X      NV4     NV4     PIX     SYS     0-31,128-159    0               N/A
GPU2    NV4     NV4      X      NV4     SYS     PIX     96-127,224-255  3               N/A
GPU3    NV4     NV4     NV4      X      SYS     SYS     64-95,192-223   2               N/A
NIC0    SYS     PIX     SYS     SYS      X      SYS
NIC1    SYS     SYS     PIX     SYS     SYS      X

Legend:

  X    = Self
  SYS  = Connection traversing PCIe as well as the SMP interconnect between NUMA nodes (e.g., QPI/UPI)
  NODE = Connection traversing PCIe as well as the interconnect between PCIe Host Bridges within a NUMA node
  PHB  = Connection traversing PCIe as well as a PCIe Host Bridge (typically the CPU)
  PXB  = Connection traversing multiple PCIe bridges (without traversing the PCIe Host Bridge)
  PIX  = Connection traversing at most a single PCIe bridge
  NV#  = Connection traversing a bonded set of # NVLinks

NIC Legend:

  NIC0: mlx5_0
  NIC1: mlx5_1
```

Thus we need to shuffle around the visible devices per rank accordingly.
