### PR TITLE
Minor bugfixes (extracthandler/fetchhandler)

### DIFF
--- a/ifsbench/data/extracthandler.py
+++ b/ifsbench/data/extracthandler.py
@@ -41,6 +41,11 @@ class ExtractHandler(DataHandler):
     def execute(self, wdir: Union[str, pathlib.Path], **kwargs) -> None:
         wdir = pathlib.Path(wdir)
 
+        if not self.archive_path.is_absolute():
+            archive_path = wdir/self.archive_path
+        else:
+            archive_path = self.archive_path
+
         target_dir = wdir
         if self.target_dir is not None:
             if self.target_dir.is_absolute():
@@ -48,5 +53,5 @@ class ExtractHandler(DataHandler):
             else:
                 target_dir = wdir / self.target_dir
 
-        debug(f"Unpack archive {str(self.archive_path)} to {str(target_dir)}.")
-        shutil.unpack_archive(self.archive_path, target_dir)
+        debug(f"Unpack archive {str(archive_path)} to {str(target_dir)}.")
+        shutil.unpack_archive(archive_path, target_dir)

--- a/ifsbench/data/fetchhandler.py
+++ b/ifsbench/data/fetchhandler.py
@@ -62,6 +62,6 @@ class FetchHandler(DataHandler):
             with urllib.request.urlopen(self.source_url) as source, target_path.open('wb') as target:
                 shutil.copyfileobj(source, target)
         except urllib.error.URLError as ue:
-            warning("Fetching file failed: {ue}")
+            warning(f"Fetching file failed: {ue}")
             if not self.ignore_errors:
                 raise RuntimeError(str(ue)) from ue

--- a/ifsbench/data/tests/test_extracthandler.py
+++ b/ifsbench/data/tests/test_extracthandler.py
@@ -110,7 +110,7 @@ def test_extracthandler_execute(
         tmp_path: `pathlib.Path`
             pytest-provided temporary directory which acts as our working directory.
 
-        fixture_archive:
+        archive:
             Directory structure inside the archive.
 
         archive_path:
@@ -162,12 +162,14 @@ def test_extracthandler_execute(
             tmp_path / archive_path, archive_type, pack_path
         )
 
+        archive_path = Path(archive_path).relative_to(tmp_path)
+
     # Actually extract the archive.
     config = {'archive_path': archive_path}
     if target_dir:
         config['target_dir'] = target_dir
 
-    handler = ExtractHandler.from_config(config)
+    handler = ExtractHandler(**config)
     handler.execute(tmp_path)
 
     # Build the path where the data should now be. As target_dir may be

--- a/ifsbench/data/tests/test_extracthandler.py
+++ b/ifsbench/data/tests/test_extracthandler.py
@@ -26,9 +26,10 @@ from ifsbench.data import ExtractHandler
     'target_dir, target_valid',
     [('somewhere/archive.tar', True), (None, True), (2, False)],
 )
-def test_extracthandler_init(archive_path, archive_valid, target_dir, target_valid):
+def test_extracthandler_from_config(archive_path, archive_valid, target_dir, target_valid):
     """
-    Initialise the ExtractHandler and make sure that only correct values are accepted.
+    Initialise the ExtractHandler using the from_config function and make
+    sure that only correct values are accepted.
     """
     if archive_valid and target_valid:
         context = nullcontext()
@@ -40,6 +41,30 @@ def test_extracthandler_init(archive_path, archive_valid, target_dir, target_val
 
     with context:
         ExtractHandler.from_config(config)
+
+@pytest.mark.parametrize(
+    'archive_path,archive_valid',
+    [('somewhere/archive.tar', True), (None, False), (2, False)],
+)
+@pytest.mark.parametrize(
+    'target_dir, target_valid',
+    [('somewhere/archive.tar', True), (None, True), (2, False)],
+)
+def test_extracthandler_init(archive_path, archive_valid, target_dir, target_valid):
+    """
+    Initialise the ExtractHandler using the constructor and make
+    sure that only correct values are accepted.
+    """
+    if archive_valid and target_valid:
+        context = nullcontext()
+    else:
+        context = pytest.raises(Exception)
+    config = {'archive_path': archive_path}
+    if target_dir:
+        config['target_dir'] = target_dir
+
+    with context:
+        ExtractHandler(**config)
 
 
 @pytest.mark.parametrize(
@@ -169,7 +194,7 @@ def test_extracthandler_execute(
     if target_dir:
         config['target_dir'] = target_dir
 
-    handler = ExtractHandler(**config)
+    handler = ExtractHandler.from_config(config)
     handler.execute(tmp_path)
 
     # Build the path where the data should now be. As target_dir may be


### PR DESCRIPTION
Fixed some minor bugs that I've encountered.

- ExtractHandler wasn't handling relative paths well. I've fixed this and adapted the tests.
- There was a missing `f"` in a formatting string in the FetchHandler.