### PR TITLE
Added datahandler for namelist sanitisation.

### DIFF
--- a/ifsbench/command_line/nml_diff.py
+++ b/ifsbench/command_line/nml_diff.py
@@ -9,7 +9,7 @@ import click
 import f90nml
 
 from ifsbench.logging import colors, logger, INFO
-from ifsbench.namelist import namelist_diff, sanitize_namelist
+from ifsbench.namelist import namelist_diff, sanitise_namelist
 
 
 def print_neutral(indent, msg, *args, **kwargs):
@@ -75,8 +75,8 @@ def nml_diff(color, namelist1, namelist2):
     nml1 = f90nml.read(namelist1)
     nml2 = f90nml.read(namelist2)
 
-    nml1 = sanitize_namelist(nml1)
-    nml2 = sanitize_namelist(nml2)
+    nml1 = sanitise_namelist(nml1)
+    nml2 = sanitise_namelist(nml2)
 
     diff = namelist_diff(nml1, nml2)
     if diff:

--- a/ifsbench/data/namelisthandler.py
+++ b/ifsbench/data/namelisthandler.py
@@ -166,6 +166,9 @@ class NamelistHandler(DataHandler):
         debug(f"Modify namelist {input_path}.")
         namelist = f90nml.read(input_path)
 
+        namelist.uppercase = True
+        namelist.end_comma = True
+
         for override in self.overrides:
             override.apply(namelist)
 

--- a/ifsbench/tests/test_namelist.py
+++ b/ifsbench/tests/test_namelist.py
@@ -17,7 +17,7 @@ try:
     from collections import OrderedDict
 except ImportError:
     OrderedDict = dict
-from ifsbench import sanitize_namelist, namelist_diff, IFSNamelist
+from ifsbench import sanitise_namelist, namelist_diff, IFSNamelist
 
 
 @pytest.fixture(scope='module', name='here')
@@ -63,7 +63,7 @@ def available_modes(xfail=None, skip=None):
 
 
 @pytest.mark.parametrize('mode', available_modes())
-def test_sanitize_namelist(mode):
+def test_sanitise_namelist(mode):
     nml_string = """
 &a
     foo = 4
@@ -85,17 +85,17 @@ def test_sanitize_namelist(mode):
             f.write(nml_string)
         nml = f90nml.read(nml_file)
 
-    sanitized = sanitize_namelist(nml, merge_strategy='first', mode=mode)
-    assert sanitized.todict() == {'a': {'foo': 4, 'foobar': 3}, 'b': {'bar': 1, 'foo': 2}}
+    sanitised = sanitise_namelist(nml, merge_strategy='first', mode=mode)
+    assert sanitised.todict() == {'a': {'foo': 4, 'foobar': 3}, 'b': {'bar': 1, 'foo': 2}}
 
-    sanitized = sanitize_namelist(nml, merge_strategy='last', mode=mode)
-    assert sanitized.todict() == {'a': {'foo': 1, 'bar': 2}, 'b': {'bar': 1, 'foo': 2}}
+    sanitised = sanitise_namelist(nml, merge_strategy='last', mode=mode)
+    assert sanitised.todict() == {'a': {'foo': 1, 'bar': 2}, 'b': {'bar': 1, 'foo': 2}}
 
-    sanitized = sanitize_namelist(nml, merge_strategy='merge_first', mode=mode)
-    assert sanitized.todict() == {'a': {'foo': 4, 'foobar': 3, 'bar': 2}, 'b': {'bar': 1, 'foo': 2}}
+    sanitised = sanitise_namelist(nml, merge_strategy='merge_first', mode=mode)
+    assert sanitised.todict() == {'a': {'foo': 4, 'foobar': 3, 'bar': 2}, 'b': {'bar': 1, 'foo': 2}}
 
-    sanitized = sanitize_namelist(nml, merge_strategy='merge_last', mode=mode)
-    assert sanitized.todict() == {'a': {'foo': 1, 'foobar': 3, 'bar': 2}, 'b': {'bar': 1, 'foo': 2}}
+    sanitised = sanitise_namelist(nml, merge_strategy='merge_last', mode=mode)
+    assert sanitised.todict() == {'a': {'foo': 1, 'foobar': 3, 'bar': 2}, 'b': {'bar': 1, 'foo': 2}}
 
 
 def test_empty_namelist():
@@ -122,17 +122,17 @@ def test_empty_namelist():
         nml_file.write_text(nml_string)
         nml = f90nml.read(nml_file)
 
-    sanitized = sanitize_namelist(nml, merge_strategy='first')
-    assert sanitized.todict() == {'a': {'foo': 4, 'foobar': 3}, 'b': {'bar': 1, 'foo': 2}, 'c':{}}
+    sanitised = sanitise_namelist(nml, merge_strategy='first')
+    assert sanitised.todict() == {'a': {'foo': 4, 'foobar': 3}, 'b': {'bar': 1, 'foo': 2}, 'c':{}}
 
-    sanitized = sanitize_namelist(nml, merge_strategy='last')
-    assert sanitized.todict() == {'a':{}, 'b': {'bar': 1, 'foo': 2}, 'c':{}}
+    sanitised = sanitise_namelist(nml, merge_strategy='last')
+    assert sanitised.todict() == {'a':{}, 'b': {'bar': 1, 'foo': 2}, 'c':{}}
 
-    sanitized = sanitize_namelist(nml, merge_strategy='merge_first')
-    assert sanitized.todict() == {'a': {'foo': 4, 'foobar': 3, 'bar': 2}, 'b': {'bar': 1, 'foo': 2}, 'c':{}}
+    sanitised = sanitise_namelist(nml, merge_strategy='merge_first')
+    assert sanitised.todict() == {'a': {'foo': 4, 'foobar': 3, 'bar': 2}, 'b': {'bar': 1, 'foo': 2}, 'c':{}}
 
-    sanitized = sanitize_namelist(nml, merge_strategy='merge_last')
-    assert sanitized.todict() == {'a': {'foo': 1, 'foobar': 3, 'bar': 2}, 'b': {'bar': 1, 'foo': 2}, 'c':{}}
+    sanitised = sanitise_namelist(nml, merge_strategy='merge_last')
+    assert sanitised.todict() == {'a': {'foo': 1, 'foobar': 3, 'bar': 2}, 'b': {'bar': 1, 'foo': 2}, 'c':{}}
 
 
 def test_namelist_diff():
@@ -328,7 +328,7 @@ def test_namelist_duplicate_key(here, mode):
         assert _converted_nml_1 == _converted_nml_2
 
 
-@pytest.mark.parametrize('mode', available_modes(xfail=[('f90nml', 'nml["someval"] is a list as not sanitized')]))
+@pytest.mark.parametrize('mode', available_modes(xfail=[('f90nml', 'nml["someval"] is a list as not sanitised')]))
 def test_namelist_duplicate_key_set_val(here, mode):
 
     nml_template = here / 'namelists/template.nml'


### PR DESCRIPTION
Added an additional datahandler that can sanitise namelists (i.e. resolve duplicates). This is necessary for using this in IFS, as the default IFS namelists are usually not sanitised.