### PR TITLE
Protect against future setuptools changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 # Make sure we use setuptools and have all required dependencies for that
 [build-system]
 requires = [
-  "setuptools >= 61",
+  "setuptools >= 75.0.0,<80.10.0",
   "wheel",
-  "setuptools_scm >= 6.2",
+  "setuptools_scm[toml] >= 6.2,<9.3",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
Carry-over of #62 to main, in lieu of #63.

The packaging switch contributed to 0.1.3 in #61 is already in use in main.