### PR TITLE
Symlink fixes for data handlers

### DIFF
--- a/ifsbench/data/namelisthandler.py
+++ b/ifsbench/data/namelisthandler.py
@@ -167,4 +167,10 @@ class NamelistHandler(DataHandler):
         for override in self.overrides:
             override.apply(namelist)
 
+        # If output_path exists and is a symlink, f90nml will just overwrite
+        # the target of the namelist. This is not ideal, therefore we delete
+        # output_path, if it is a symlink.
+        if output_path.is_symlink():
+            output_path.unlink()
+
         namelist.write(output_path, force=True)

--- a/ifsbench/data/renamehandler.py
+++ b/ifsbench/data/renamehandler.py
@@ -8,6 +8,7 @@
 from enum import Enum
 from functools import cached_property
 from pathlib import Path
+import os
 import re
 import shutil
 from typing import Union
@@ -75,8 +76,8 @@ class RenameHandler(DataHandler):
             if f.is_dir():
                 continue
 
-            dest = Path(self._pattern.sub(self.repl, str(f.relative_to(wdir))))
-            dest = (wdir / dest).resolve()
+            dest = self._pattern.sub(self.repl, str(f.relative_to(wdir)))
+            dest = Path(os.path.normpath(wdir/dest))
 
             if f != dest:
                 path_mapping[f] = dest

--- a/ifsbench/data/tests/test_namelisthandler.py
+++ b/ifsbench/data/tests/test_namelisthandler.py
@@ -462,4 +462,3 @@ def test_namelisthandler_write_symlink(
 
     assert namelist1['namelist1']['int'] == 5
     assert namelist2['namelist1']['int'] == 6
-

--- a/ifsbench/data/tests/test_namelisthandler.py
+++ b/ifsbench/data/tests/test_namelisthandler.py
@@ -12,7 +12,7 @@ Tests for the NamelistHandler class.
 from contextlib import nullcontext
 from pathlib import Path
 
-from f90nml import Namelist
+from f90nml import Namelist, read
 import pytest
 
 from ifsbench.data import NamelistHandler, NamelistOverride, NamelistOperation
@@ -431,3 +431,35 @@ def test_namelisthandler_execute(
         assert (tmp_path / output_path).exists()
     else:
         assert Path(output_path).exists()
+
+def test_namelisthandler_write_symlink(
+    tmp_path,
+):
+    """
+    Test that writing a namelist to a symlink will create a new namelist
+    file and not overwrite the target of the symlink.
+    """
+
+    namelist = Namelist()
+
+    namelist['namelist1'] = {'int': 5}
+
+    namelist.write(tmp_path/'namelist')
+    (tmp_path/'sym_namelist').symlink_to(tmp_path/'namelist')
+
+    override = NamelistOverride(namelist='namelist1', entry='int', value=6, mode=NamelistOperation.SET)
+
+    handler = NamelistHandler(
+        input_path=tmp_path/'namelist',
+        output_path=tmp_path/'sym_namelist',
+        overrides=[override]
+    )
+
+    handler.execute(tmp_path)
+
+    namelist1 = read(tmp_path/'namelist')
+    namelist2 = read(tmp_path/'sym_namelist')
+
+    assert namelist1['namelist1']['int'] == 5
+    assert namelist2['namelist1']['int'] == 6
+

--- a/ifsbench/data/tests/test_renamehandler.py
+++ b/ifsbench/data/tests/test_renamehandler.py
@@ -157,3 +157,23 @@ def test_renamehandler_from_filename(
 
     for f in files_out:
         assert (tmp_path / f).exists()
+
+
+def test_renamehandler_symlink(tmp_path):
+    """
+    Test that a RenameHandler deals with symlinks correctly.
+    """
+
+    (tmp_path/'subdir').mkdir(parents=True, exist_ok=True)
+    (tmp_path/'subdir/file.txt').touch()
+    (tmp_path/'subdir/symlink').symlink_to(tmp_path/'subdir/file.txt')
+
+    handler = RenameHandler(pattern='file', repl='dir', mode=RenameMode.SYMLINK)
+
+    handler.execute(tmp_path)
+
+    assert (tmp_path/'subdir/dir.txt').exists()
+    assert (tmp_path/'subdir/file.txt').exists()
+    assert (tmp_path/'subdir/symlink').exists()
+
+    assert (tmp_path/'subdir/symlink').resolve() == tmp_path/'subdir/file.txt'


### PR DESCRIPTION
I stumbled over two symlink-related bugs in ifsbench that I encountered while working on the tests for IFS. I've fixed these and added additional tests for this behaviour

### RenameHandler

When renaming a file that's not a "proper" file but a symlink, the `RenameHandler` did not use the name of the file but the actual resolved target of the symlink. This could caused weird cyclic-symlink issues when the `SYMLINK` rename mode was used. I've fixed this by using `os.path.normpath` instead of `Path.resolve`. The latter not only normalises the path but also resolves all symlinks.


### NamelistHandler

When writing a namelist, to a path where a symlink exists, `f90nml` wrote to the target of the symlink, instead of removing the symlink and creating a new file in its place.

