### PR TITLE
cleanup: remove duplication of absolute path check

### DIFF
--- a/ifsbench/data/datahandler.py
+++ b/ifsbench/data/datahandler.py
@@ -12,7 +12,7 @@ from typing import Union
 
 from ifsbench.serialisation_mixin import SubclassableSerialisationMixin
 
-__all__ = ['DataHandler']
+__all__ = ["DataHandler", "absolutise_path"]
 
 
 class DataHandler(SubclassableSerialisationMixin):
@@ -37,3 +37,23 @@ class DataHandler(SubclassableSerialisationMixin):
             unless absolute paths are given.
         """
         return NotImplemented
+
+
+def absolutise_path(wdir: Union[str, Path], target: Path) -> Path:
+    """
+    Ensure target is an absolute path.
+
+    Parameters
+    wdir    : str or :any:`pathlib.Path`
+        If the target path is not absolute, it will be in this directory.
+    target  : :any:`pathlib.Path`
+        Path which if not absolute will be inside wdir
+
+    Returns:
+       Path to target as absolute pathlib.Path
+
+    """
+    if target.is_absolute():
+        return target
+
+    return Path(wdir) / target

--- a/ifsbench/data/extracthandler.py
+++ b/ifsbench/data/extracthandler.py
@@ -9,10 +9,10 @@ import pathlib
 import shutil
 from typing import Optional, Union
 
-from ifsbench.data.datahandler import DataHandler
+from ifsbench.data.datahandler import absolutise_path, DataHandler
 from ifsbench.logging import debug
 
-__all__ = ['ExtractHandler']
+__all__ = ["ExtractHandler"]
 
 
 class ExtractHandler(DataHandler):
@@ -36,19 +36,12 @@ class ExtractHandler(DataHandler):
     target_dir: Optional[pathlib.Path] = None
 
     def execute(self, wdir: Union[str, pathlib.Path], **kwargs) -> None:
-        wdir = pathlib.Path(wdir)
+        archive_path = absolutise_path(wdir, self.archive_path)
 
-        if not self.archive_path.is_absolute():
-            archive_path = wdir/self.archive_path
-        else:
-            archive_path = self.archive_path
-
-        target_dir = wdir
         if self.target_dir is not None:
-            if self.target_dir.is_absolute():
-                target_dir = self.target_dir
-            else:
-                target_dir = wdir / self.target_dir
+            target_dir = absolutise_path(wdir, self.target_dir)
+        else:
+            target_dir = pathlib.Path(wdir)
 
         debug(f"Unpack archive {str(archive_path)} to {str(target_dir)}.")
         shutil.unpack_archive(archive_path, target_dir)

--- a/ifsbench/data/fetchhandler.py
+++ b/ifsbench/data/fetchhandler.py
@@ -11,10 +11,11 @@ import shutil
 import urllib.error
 import urllib.request
 
-from ifsbench.data.datahandler import DataHandler
+from ifsbench.data.datahandler import absolutise_path, DataHandler
 from ifsbench.logging import debug, info, warning
 
-__all__ = ['FetchHandler']
+__all__ = ["FetchHandler"]
+
 
 class FetchHandler(DataHandler):
     """
@@ -36,12 +37,7 @@ class FetchHandler(DataHandler):
     ignore_errors: bool = True
 
     def execute(self, wdir: Union[str, pathlib.Path], **kwargs) -> None:
-        wdir = pathlib.Path(wdir)
-
-        target_path = self.target_path
-
-        if not self.target_path.is_absolute():
-            target_path = wdir/self.target_path
+        target_path = absolutise_path(wdir, self.target_path)
 
         # Create the necessary parent folders.
         target_path.parent.mkdir(parents=True, exist_ok=True)
@@ -56,7 +52,9 @@ class FetchHandler(DataHandler):
         debug(f"Download file from {self.source_url} to {target_path}.")
 
         try:
-            with urllib.request.urlopen(self.source_url) as source, target_path.open('wb') as target:
+            with urllib.request.urlopen(self.source_url) as source, target_path.open(
+                "wb"
+            ) as target:
                 shutil.copyfileobj(source, target)
         except urllib.error.URLError as ue:
             warning(f"Fetching file failed: {ue}")

--- a/ifsbench/data/renamehandler.py
+++ b/ifsbench/data/renamehandler.py
@@ -18,7 +18,7 @@ from pydantic import computed_field
 from ifsbench.data.datahandler import DataHandler
 from ifsbench.logging import debug
 
-__all__ = ['RenameHandler', 'RenameMode']
+__all__ = ["RenameHandler", "RenameMode"]
 
 
 class RenameMode(str, Enum):
@@ -27,13 +27,13 @@ class RenameMode(str, Enum):
     """
 
     #: Copy the file from its current place to the new location.
-    COPY = 'copy'
+    COPY = "copy"
 
     #: Create a symlink in the new location, pointing to its current location.
-    SYMLINK = 'symlink'
+    SYMLINK = "symlink"
 
     #: Move the file from its current place to the new location.
-    MOVE = 'move'
+    MOVE = "move"
 
 
 class RenameHandler(DataHandler):
@@ -70,12 +70,12 @@ class RenameHandler(DataHandler):
         # modified.
         path_mapping = {}
 
-        for f in wdir.rglob('*'):
+        for f in wdir.rglob("*"):
             if f.is_dir():
                 continue
 
             dest = self._pattern.sub(self.repl, str(f.relative_to(wdir)))
-            dest = Path(os.path.normpath(wdir/dest))
+            dest = Path(os.path.normpath(wdir / dest))
 
             if f != dest:
                 path_mapping[f] = dest


### PR DESCRIPTION
Several places use that same code in some form. Pulled it out into its own function. Left it in data/datahandler.py for now since it's not needed outside that module.

I also ran `black` for formatting, hence some changes to line breaks and single quotes to double quotes.