### PR TITLE
Resolved pylint issues

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -33,13 +33,6 @@ load-plugins=
 # Pickle collected data for later comparisons.
 persistent=yes
 
-# Specify a configuration file.
-#rcfile=
-
-# When enabled, pylint would attempt to guess common misconfiguration and emit
-# user-friendly hints instead of false-positive error messages.
-suggestion-mode=yes
-
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
 unsafe-load-any-extension=no

--- a/ifsbench/gribfile.py
+++ b/ifsbench/gribfile.py
@@ -92,7 +92,7 @@ class GribModification(ABC):
             raise RuntimeError(
                 'Cannot modify GRIB files - pygrib or eccodes not available.'
             )
-
+    # pylint: disable=possibly-used-before-assignment
     @abstractmethod
     def modify_message(self, grb: gribmessage) -> gribmessage:
         """Modifies the data in that GRIB message."""
@@ -102,6 +102,7 @@ class GribModification(ABC):
 class NoGribModification(GribModification):
     """Does not apply any modification."""
 
+    # pylint: disable=possibly-used-before-assignment
     def modify_message(self, grb: gribmessage) -> gribmessage:
         return grb
 

--- a/ifsbench/validation/frame_close_validation.py
+++ b/ifsbench/validation/frame_close_validation.py
@@ -72,4 +72,3 @@ class FrameCloseValidation:
         mismatch = [(frame1.index[i], frame1.columns[j]) for i,j in mismatch]
 
         return numpy.all(close), mismatch
-        


### PR DESCRIPTION
- Removed deprecated entry in pylintrc, mirroring what was done in https://github.com/ecmwf-ifs/loki/commit/7f37d24f7ebf6e9763f25ce2dc8d386222860faa. Thanks @mlange05.
- Prevented pylint from complaining about an used-before-assignment issue in `gribfile.py` (code is fine, pylint simply doesn't understand the initialisation there).