### PR TITLE
MPI and Srun launchers now set OMP_NUM_THREADS automatically

### DIFF
--- a/ifsbench/launch/mpirunlauncher.py
+++ b/ifsbench/launch/mpirunlauncher.py
@@ -96,6 +96,16 @@ class MpirunLauncher(Launcher):
                     )
                 )
 
+        if job.cpus_per_task:
+            # We automatically set OMP_NUM_THREADS here. This may not be
+            # necessary for each application (as not all application may use
+            # OpenMP-based multithreading.
+            env_pipeline.add(EnvHandler(
+                mode=EnvOperation.APPEND,
+                key='OMP_NUM_THREADS',
+                value=str(job.cpus_per_task)
+            ))
+
         flags += cmd
 
         env = env_pipeline.execute()

--- a/ifsbench/launch/srunlauncher.py
+++ b/ifsbench/launch/srunlauncher.py
@@ -115,6 +115,16 @@ class SrunLauncher(Launcher):
                     )
                 )
 
+        if job.cpus_per_task:
+            # We automatically set OMP_NUM_THREADS here. This may not be
+            # necessary for each application (as not all application may use
+            # OpenMP-based multithreading.
+            env_pipeline.add(EnvHandler(
+                mode=EnvOperation.APPEND,
+                key='OMP_NUM_THREADS',
+                value=str(job.cpus_per_task)
+            ))
+
         flags += cmd
 
         env = env_pipeline.execute()

--- a/ifsbench/launch/tests/test_mpirunlauncher.py
+++ b/ifsbench/launch/tests/test_mpirunlauncher.py
@@ -41,7 +41,8 @@ def fixture_test_env_none():
 @pytest.mark.parametrize(
     'cmd,job_in,library_paths,env_pipeline_name,custom_flags,env_out',
     [
-        (['ls', '-l'], {'tasks': 64, 'cpus_per_task': 4}, [], 'test_env_none', [], {}),
+        (['ls', '-l'], {'tasks': 64, 'cpus_per_task': 4}, [], 'test_env_none',
+            [], {'OMP_NUM_THREADS': '4'}),
         (
             ['something'],
             {},

--- a/ifsbench/launch/tests/test_srunlauncher.py
+++ b/ifsbench/launch/tests/test_srunlauncher.py
@@ -41,7 +41,8 @@ def fixture_test_env_none():
 @pytest.mark.parametrize(
     'cmd,job_in,library_paths,env_pipeline_name,custom_flags,env_out',
     [
-        (['ls', '-l'], {'tasks': 64, 'cpus_per_task': 4}, [], 'test_env_none', [], {}),
+        (['ls', '-l'], {'tasks': 64, 'cpus_per_task': 4}, [], 'test_env_none',
+            [], {'OMP_NUM_THREADS': '4'}),
         (
             ['something'],
             {},


### PR DESCRIPTION
Until now, the MPI/Srun launchers didn't set the `OMP_NUM_THREADS` environment variable as this is somewhat application specific (not all applications are bound to use OpenMP).

Still, after consultation with @mlange05 I guess that it's less error-prone if the launchers set `OMP_NUM_THREADS` automatically. If this leads to unwanted behaviour with some applications, these applications can just unset/update `OMP_NUM_THREADS`.