### PR TITLE
Use --map-by in MpirunLauncher instead of --cpus-per-proc.

### DIFF
--- a/ifsbench/launch/mpirunlauncher.py
+++ b/ifsbench/launch/mpirunlauncher.py
@@ -23,7 +23,6 @@ class MpirunLauncher(Launcher):
         'tasks': '-n {}',
         'tasks_per_node': '--npernode {}',
         'tasks_per_socket': '--npersocket {}',
-        'cpus_per_task': '--cpus-per-proc {}',
     }
 
     _bind_options_map = {
@@ -51,10 +50,24 @@ class MpirunLauncher(Launcher):
         ):
             warning('Specified remote distribution option ignored in MpirunLauncher')
 
-        if job.distribute_local is None or job.distribute_local in do_nothing:
+        # By default use core mapping. At least that's the default in the
+        # OpenMPI implementation
+        # (https://docs.open-mpi.org/en/main/man-openmpi/man1/mpirun.1.html#label-schizo-ompi-map-by).
+        map_by = 'core'
+
+        if job.distribute_local and job.distribute_local not in do_nothing:
+            map_by = self._distribution_options_map[job.distribute_local]
+        elif job.cpus_per_task is None:
+            # If no local distribution must be set and the number of threads
+            # isn't specified, we don't have to add any flags.
             return []
 
-        return ['--map-by', f'{self._distribution_options_map[job.distribute_local]}']
+        # If multithreading is used, we have to specify the number of threads
+        # per process in the map_by statement.
+        if job.cpus_per_task:
+            return ['--map-by', f'{map_by}:PE={job.cpus_per_task}']
+
+        return ['--map-by', f'{map_by}']
 
     def prepare(
         self,

--- a/ifsbench/launch/mpirunlauncher.py
+++ b/ifsbench/launch/mpirunlauncher.py
@@ -43,6 +43,7 @@ class MpirunLauncher(Launcher):
         do_nothing = [
             CpuDistribution.DISTRIBUTE_DEFAULT,
             CpuDistribution.DISTRIBUTE_USER,
+            None
         ]
         if (
             hasattr(job, 'distribute_remote')

--- a/ifsbench/launch/tests/test_mpirunlauncher.py
+++ b/ifsbench/launch/tests/test_mpirunlauncher.py
@@ -121,7 +121,7 @@ def test_mpirunLauncher_prepare_run_dir(
             [],
             'test_env_none',
             [],
-            ['mpirun', '-n', '64', '--cpus-per-proc', '4', 'ls', '-l'],
+            ['mpirun', '-n', '64', '--map-by', 'core:PE=4', 'ls', '-l'],
         ),
         (
             ['something'],
@@ -149,6 +149,18 @@ def test_mpirunLauncher_prepare_run_dir(
             'test_env',
             [],
             ['mpirun', '--bind-to', 'hwthread', '--map-by', 'numa', 'bind_hell'],
+        ),
+        (
+            ['bind_hell'],
+            {
+                'cpus_per_task': 2,
+                'bind': CpuBinding.BIND_THREADS,
+                'distribute_local': CpuDistribution.DISTRIBUTE_CYCLIC,
+            },
+            ['/library/path'],
+            'test_env',
+            [],
+            ['mpirun', '--bind-to', 'hwthread', '--map-by', 'numa:PE=2', 'bind_hell'],
         ),
     ],
 )


### PR DESCRIPTION
The `--cpus-per-proc` flag for `mpirun` has been deprecated for a while and support for this seems to have ended in some MPI implementations now. Therefore, I've tried to replace it by the modern `--map-by` approach.

@reuterbal : Could you double-check that I am not doing something stupid here? I am not an expert on doing MPI bindings - and I have to combine the multi-threading and the binding here.

@mlange05 : Would be great if you could verify that this works as intended.