### PR TITLE
Fix DrHook tests that started failing with pandas 3.0.0

### DIFF
--- a/ifsbench/tests/test_drhook.py
+++ b/ifsbench/tests/test_drhook.py
@@ -15,7 +15,7 @@ import pytest
 from ifsbench import DrHookRecord
 
 def get_data(df, routine, metric):
-    return df.loc[df['routine'] == routine][metric][0]
+    return (df.loc[df['routine'] == routine][metric]).iloc[0]
 
 def get_metadata(df, metric):
     return df.loc[0][metric]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ requires-python = ">=3.8"
 license = {text = "Apache-2.0"}
 dynamic = ["version", "readme"]
 dependencies = [
-  "pandas >= 1.4.0,<3.0.0",   # essential for benchmarking data
+  "pandas >= 1.4.0",   # essential for benchmarking data
   "pyyaml",   # essential for file handling
   "pydantic", # essential for typing and configs
   "click",    # essential for CLI scripts


### PR DESCRIPTION
It seems the direct access by index no longer works, but using .iloc fixes the issue.

Fixes https://github.com/ecmwf-ifs/ifsbench/issues/81