### PR TITLE
Fixed serialisation with nested SubclassableSerialisationMixin classes

### DIFF
--- a/ifsbench/serialisation_mixin.py
+++ b/ifsbench/serialisation_mixin.py
@@ -151,25 +151,32 @@ class SubclassableSerialisationMixin(SerialisationMixin):
         # (self). As the model_dump function eventually invokes this function
         # again, we have to make sure that we are not stuck in an endless
         # recursion.
-        # To avoid this, we add a flag to the info.context object.
+        # To avoid this, we register if we started a recursion for this object,
+        # using the info.context object.
 
-
-        # Check if we are in a recursive call to this function. If we are, just
-        # use the default serialisation handler (which this function wraps) to
-        # do the serialisation.
-        if info.context:
-            recursive = info.context.get('recursive', False)
-
-            if recursive:
-                return handler(self)
-
-        # If we are not recursive yet, add the 'recursive' flag to the context.
-        if info.context == dict:
+        if isinstance(info.context, dict):
             context = dict(info.context)
         else:
             context = {}
 
-        context['recursive'] = True
+        if 'recursive' not in context:
+            context['recursive'] = {}
+
+        # We use the ID of self to detect if we've called this recursively or not.
+        me = id(self)
+
+        # Check if we are in a recursive call to this function. If we are, just
+        # use the default serialisation handler (which this function wraps) to
+        # do the serialisation.
+        recursive = context['recursive'].get(me, False)
+
+        if recursive:
+            # We exit the recursion here by calling the handler directly. Delete
+            # the recursive flag here, otherwise this may cause issues later.
+            del context['recursive'][me]
+            return handler(self)
+
+        context['recursive'][me] = True
 
         # Convert options into a dictionary so we can pass it to model_dump.
         # Unfortunately, the info object has no routine for this inbuilt and

--- a/ifsbench/tests/test_serialisation_mixin.py
+++ b/ifsbench/tests/test_serialisation_mixin.py
@@ -13,7 +13,6 @@ from pydantic import ValidationError
 
 from ifsbench import SerialisationMixin, SubclassableSerialisationMixin, CLASSNAME
 
-
 class TestImpl(SerialisationMixin):
     field_str: str
     field_int: int
@@ -98,6 +97,12 @@ def test_dumb_config_with_class_succeeds():
     expected[CLASSNAME] = 'TestImpl'
     assert ti.dump_config(with_class=True) == expected
 
+class SecondBaseClass(SubclassableSerialisationMixin):
+    str_value: str
+
+
+class SecondChildClass(SecondBaseClass):
+    bool_value: bool
 
 class TestBase(SubclassableSerialisationMixin):
     float_value: float
@@ -109,10 +114,12 @@ class TestChild1(TestBase):
 class TestChild2(TestBase):
     first_int: int
     second_int: int
-
+    child: SecondBaseClass
 
 class TestCombine(SerialisationMixin):
     child: TestBase
+
+
 
 def test_subclass_serialisation():
     """
@@ -131,7 +138,8 @@ def test_subclass_serialisation():
         }
     }
 
-    obj = TestCombine(child=TestChild2(first_int=5, second_int=6, float_value=2.1))
+    obj = TestCombine(child=TestChild2(first_int=5, second_int=6, float_value=2.1,
+      child=SecondChildClass(bool_value=False, str_value='hello')))
 
     config = obj.dump_config()
 
@@ -140,6 +148,7 @@ def test_subclass_serialisation():
             'class_name': 'TestChild2',
             'first_int': 5,
             'second_int': 6,
-            'float_value': 2.1
+            'float_value': 2.1,
+            'child': {'class_name': 'SecondChildClass', 'bool_value': False, 'str_value': 'hello'}
         }
     }


### PR DESCRIPTION
Serialisation wasn't working when two `SubclassableSerialisationMixin` classes were nested. The reason for this was the handling of recursive calls in `_serialize_model`. I've updated this by having a separate recursion flag for each object (using `id(object)`, instead of having a single global recursion flag.