### PR TITLE
Fixed bugs in BashLauncher

### DIFF
--- a/ifsbench/launch/bashlauncher.py
+++ b/ifsbench/launch/bashlauncher.py
@@ -60,8 +60,11 @@ class BashLauncher(LauncherWrapper):
                 debug(f'Ignore non-standard bash name {key} in BashLauncher.')
                 continue
 
+            if value is None:
+                continue
+
             # We set the environment variables inside a "..." block. This means
-            # that we have to escpae certain special characters (", $, `).
+            # that we have to escape certain special characters (", $, `).
             escaped_value = value.replace('$', '\\$')
             escaped_value = escaped_value.replace('"', '\\"')
             escaped_value = escaped_value.replace('`', '\\`')

--- a/ifsbench/launch/bashlauncher.py
+++ b/ifsbench/launch/bashlauncher.py
@@ -65,9 +65,9 @@ class BashLauncher(LauncherWrapper):
 
             # We set the environment variables inside a "..." block. This means
             # that we have to escape certain special characters (", $, `).
-            escaped_value = value.replace('$', '\\$')
-            escaped_value = escaped_value.replace('"', '\\"')
-            escaped_value = escaped_value.replace('`', '\\`')
+            chars_to_escape = ['$', '"', '`']
+            trans = str.maketrans({char: '\\'+char for char in chars_to_escape})
+            escaped_value = value.translate(trans)
             f.write(f'export {key}="')
             f.write(escaped_value)
             f.write("\"\n")

--- a/ifsbench/launch/bashlauncher.py
+++ b/ifsbench/launch/bashlauncher.py
@@ -7,11 +7,13 @@
 
 from copy import deepcopy
 import datetime
+import re
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, TextIO
 
 from ifsbench.env import EnvPipeline
 from ifsbench.launch.launcher import LauncherWrapper, LaunchData
+from ifsbench.logging import debug
 
 
 class BashLauncher(LauncherWrapper):
@@ -23,12 +25,54 @@ class BashLauncher(LauncherWrapper):
     a bash script, using the path ``run_dir/bash_scripts/command_time.sh``.
     """
 
-    def _write_bash_file(self, f, launch_data):
+    def _write_header(self, f: TextIO, header: str):
+        """
+        Write a "header" to a file. A header is simply a comment of the form
+
+        ############
+        # The header
+        ###########
+        """
+        f.write("\n")
+        f.write('#' * 60)
+        f.write("\n")
+        f.write(f'# {header}')
+        f.write("\n")
+        f.write('#' * 60)
+        f.write("\n")
+        f.write("\n")
+
+    def _write_bash_file(self, f: TextIO, launch_data: LaunchData):
+        """
+        Write the content of a LaunchData object to a bash script.
+        """
         f.write("#! /bin/bash\n\n")
 
-        for key, value in launch_data.env.items():
-            f.write(f'export {key}="{value}"\n')
+        self._write_header(f, "Specify environment")
+        env_name_check = re.compile(r'[a-zA-Z_][a-zA-Z_0-9]*')
 
+        for key, value in launch_data.env.items():
+            # Check that the current "environment variable" is an actual
+            # variable. For example, bash function definitions may be in
+            # `launch_data.env` but end with `_%%` and are not proper
+            # environment variables. We skip these.
+            if not env_name_check.fullmatch(key):
+                debug(f'Ignore non-standard bash name {key} in BashLauncher.')
+                continue
+
+            # We set the environment variables inside a "..." block. This means
+            # that we have to escpae certain special characters (", $, `).
+            escaped_value = value.replace('$', '\\$')
+            escaped_value = escaped_value.replace('"', '\\"')
+            escaped_value = escaped_value.replace('`', '\\`')
+            f.write(f'export {key}="')
+            f.write(escaped_value)
+            f.write("\"\n")
+
+        self._write_header(f, "Specify launch command")
+
+        f.write(f'cd "{launch_data.run_dir}"')
+        f.write("\n")
         for c in launch_data.cmd:
             f.write(f'"{c}" ')
 
@@ -51,9 +95,6 @@ class BashLauncher(LauncherWrapper):
         time_str = datetime.datetime.now(datetime.timezone.utc).strftime(
             "%Y-%m-%d:%H-%M-%S-%f"
         )
-
-        # Derive the name of the bash script from the command. As the command
-        # may be a full path, only take the part after the last slash.
         cmd_str = cmd[0].split('/')[-1]
 
         script_path = script_dir / f"{cmd_str}_{time_str}.sh"

--- a/ifsbench/launch/tests/test_bashlauncher.py
+++ b/ifsbench/launch/tests/test_bashlauncher.py
@@ -294,7 +294,7 @@ def test_bashlauncher_script(
     for key, value in base_launch_data.env.items():
         # Variables that have non-bash compatible names should not make it to
         # the bash script.
-        if not re.fullmatch('[a-zA-Z0-9_]*', key):
+        if not re.fullmatch('[a-zA-Z_][a-zA-Z_0-9]*', key):
             continue
 
         # Escape certain characters.

--- a/ifsbench/launch/tests/test_bashlauncher.py
+++ b/ifsbench/launch/tests/test_bashlauncher.py
@@ -299,8 +299,8 @@ def test_bashlauncher_script(
 
         # Escape certain characters.
         value = value.replace('$', '\\$')
-        value = value.replace('$', '\\$')
         value = value.replace('"', '\\"')
+        value = value.replace('`', '\\`')
         ref_env.append(f'export {key}="{value}"')
 
     assert set(ref_env) == set(env_lines)

--- a/ifsbench/launch/tests/test_bashlauncher.py
+++ b/ifsbench/launch/tests/test_bashlauncher.py
@@ -32,6 +32,8 @@ def fixture_test_env():
             EnvHandler(mode=EnvOperation.SET, key="SOME_VALUE", value="5"),
             EnvHandler(mode=EnvOperation.SET, key="OTHER_VALUE", value="6"),
             EnvHandler(mode=EnvOperation.DELETE, key="SOME_VALUE"),
+            EnvHandler(mode=EnvOperation.SET, key="NOT_V@LID", value="!!"),
+            EnvHandler(mode=EnvOperation.SET, key="ESCAPE_HELL", value="echo \"Something\", '22'"),
         ]
     )
 
@@ -261,6 +263,7 @@ def test_bashlauncher_script(
     header = None
     env_lines = []
     cmd_line = None
+    run_dir = None
 
     with script_path.open("r", encoding="utf-8") as f:
         header = f.readline()
@@ -273,8 +276,13 @@ def test_bashlauncher_script(
             if not line:
                 continue
 
+            if line.startswith('#'):
+                continue
+
             if line.startswith("export"):
                 env_lines.append(line.strip())
+            elif line.startswith("cd"):
+                run_dir = line.split('"')[1]
             else:
                 cmd_line = line
                 break
@@ -284,9 +292,20 @@ def test_bashlauncher_script(
     ref_env = []
 
     for key, value in base_launch_data.env.items():
+        # Variables that have non-bash compatible names should not make it to
+        # the bash script.
+        if not re.fullmatch('[a-zA-Z0-9_]*', key):
+            continue
+
+        # Escape certain characters.
+        value = value.replace('$', '\\$')
+        value = value.replace('$', '\\$')
+        value = value.replace('"', '\\"')
         ref_env.append(f'export {key}="{value}"')
 
     assert set(ref_env) == set(env_lines)
+
+    assert tmp_path == Path(run_dir)
 
     # pylint: disable=R1713
     ref_cmd_line = ""


### PR DESCRIPTION
Stumbled over a couple of bugs in the `BashLauncher` when testing it in the real world... Fixed these and improved the testing.

- The bash script didn't set `cd rundir` which caused issues when running the script manually.
- Fixed handling/escaping of certain characters inside environment variables (escape ', $, ", ...).
- The `BashLauncher` will now ignore pseudo-variables with non-bash compatible names that still pop up in `os.environ`. For example, in my environment I see bash-defined functions like `BASH_FUNC_module%%` which are not environment variables and which can't be exported.