### PR TITLE
Added pre-commit hook to run the ruff formatter.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,4 +5,4 @@ repos:
   hooks:
     # Run the formatter (only on the ifsbench directory).
     - id: ruff-format
-      files: ifsbench
+      files: ^ifsbench/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.15.4
+  hooks:
+    # Run the formatter (only on the ifsbench directory).
+    - id: ruff-format
+      files: ifsbench

--- a/README.md
+++ b/README.md
@@ -54,3 +54,14 @@ specified in `.pylintrc`:
 ```
 <build_dir>/ifsbench_env/bin/pylint --rcfile=.pylintrc ifsbench/
 ```
+
+`ifsbench` has support for [`pre-commit`](https://pre-commit.com/) to install
+a pre-commit hook that keeps formatting consistent (using `ruff`). To enable this
+run
+```
+# Install pre-commit if it isn't installed.
+pip install pre-commit
+
+cd ifsbench_repository
+pre-commit install
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
 
 [project.optional-dependencies]
 tests = [
+  "pre-commit",
   "pytest",
   "pytest-cov",
   "pylint",


### PR DESCRIPTION
Added a pre-commit hook to run the ruff formatter. This is based on the `pre-commit` tool (https://pre-commit.com/).