### PR TITLE
Never use `--map-by core` when multiple threads are used.

### DIFF
--- a/ifsbench/launch/mpirunlauncher.py
+++ b/ifsbench/launch/mpirunlauncher.py
@@ -59,8 +59,8 @@ class MpirunLauncher(Launcher):
             if job.cpus_per_task:
                 return ['--map-by', f'{map_by}:PE={job.cpus_per_task}']
             return ['--map-by', f'{map_by}']
-        else:
-            return []
+
+        return []
 
     def prepare(
         self,

--- a/ifsbench/launch/mpirunlauncher.py
+++ b/ifsbench/launch/mpirunlauncher.py
@@ -63,6 +63,11 @@ class MpirunLauncher(Launcher):
         # If multithreading is used, we have to specify the number of threads
         # per process in the map_by statement.
         if job.cpus_per_task:
+            # Using --map-by core and specifying more than one thread does not
+            # seem to work with OpenMPI. There is some discussion here:
+            # https://github.com/open-mpi/ompi/issues/7717 but I am unable to
+            # find a really good explanation for how to avoid this.
+            # As a fix, we replace `map-by core` by `map-by slot` in this case.
             if map_by == 'core':
                 map_by = 'slot'
 

--- a/ifsbench/launch/mpirunlauncher.py
+++ b/ifsbench/launch/mpirunlauncher.py
@@ -34,7 +34,7 @@ class MpirunLauncher(Launcher):
     }
 
     _distribution_options_map = {
-        CpuDistribution.DISTRIBUTE_BLOCK: 'core',
+        CpuDistribution.DISTRIBUTE_BLOCK: 'slot',
         CpuDistribution.DISTRIBUTE_CYCLIC: 'numa',
     }
 
@@ -45,35 +45,22 @@ class MpirunLauncher(Launcher):
             CpuDistribution.DISTRIBUTE_USER,
             None,
         ]
-        if hasattr(job, 'distribute_remote') and job.distribute_remote not in do_nothing:
-            warning('Specified remote distribution option ignored in MpirunLauncher')
 
-        # By default use core mapping. At least that's the default in the
-        # OpenMPI implementation
-        # (https://docs.open-mpi.org/en/main/man-openmpi/man1/mpirun.1.html#label-schizo-ompi-map-by).
-        map_by = 'core'
+        # Ignore remote distribution options. Mpirun doesn't distinguish
+        # between local/remote distribution as far as I know.
+        if job.distribute_remote is not None:
+            warning('Distribute_remote options is ignored in MpirunLauncher')
 
         if job.distribute_local and job.distribute_local not in do_nothing:
+            # Use map-by to control the distribution. If threads are used, we
+            # also have to set the PE:number-of-threads option.
+
             map_by = self._distribution_options_map[job.distribute_local]
-        elif job.cpus_per_task is None:
-            # If no local distribution must be set and the number of threads
-            # isn't specified, we don't have to add any flags.
+            if job.cpus_per_task:
+                return ['--map-by', f'{map_by}:PE={job.cpus_per_task}']
+            return ['--map-by', f'{map_by}']
+        else:
             return []
-
-        # If multithreading is used, we have to specify the number of threads
-        # per process in the map_by statement.
-        if job.cpus_per_task:
-            # Using --map-by core and specifying more than one thread does not
-            # seem to work with OpenMPI. There is some discussion here:
-            # https://github.com/open-mpi/ompi/issues/7717 but I am unable to
-            # find a really good explanation for how to avoid this.
-            # As a fix, we replace `map-by core` by `map-by slot` in this case.
-            if map_by == 'core':
-                map_by = 'slot'
-
-            return ['--map-by', f'{map_by}:PE={job.cpus_per_task}']
-
-        return ['--map-by', f'{map_by}']
 
     def prepare(
         self,

--- a/ifsbench/launch/mpirunlauncher.py
+++ b/ifsbench/launch/mpirunlauncher.py
@@ -63,6 +63,9 @@ class MpirunLauncher(Launcher):
         # If multithreading is used, we have to specify the number of threads
         # per process in the map_by statement.
         if job.cpus_per_task:
+            if map_by == 'core':
+                map_by = 'slot'
+
             return ['--map-by', f'{map_by}:PE={job.cpus_per_task}']
 
         return ['--map-by', f'{map_by}']

--- a/ifsbench/launch/tests/test_mpirunlauncher.py
+++ b/ifsbench/launch/tests/test_mpirunlauncher.py
@@ -123,6 +123,14 @@ def test_mpirunLauncher_prepare_run_dir(
             [],
             'test_env_none',
             [],
+            ['mpirun', '-n', '64', 'ls', '-l'],
+        ),
+        (
+            ['ls', '-l'],
+            {'tasks': 64, 'cpus_per_task': 4, 'distribute_local': CpuDistribution.DISTRIBUTE_BLOCK},
+            [],
+            'test_env_none',
+            [],
             ['mpirun', '-n', '64', '--map-by', 'slot:PE=4', 'ls', '-l'],
         ),
         (

--- a/ifsbench/launch/tests/test_mpirunlauncher.py
+++ b/ifsbench/launch/tests/test_mpirunlauncher.py
@@ -123,7 +123,7 @@ def test_mpirunLauncher_prepare_run_dir(
             [],
             'test_env_none',
             [],
-            ['mpirun', '-n', '64', '--map-by', 'core:PE=4', 'ls', '-l'],
+            ['mpirun', '-n', '64', '--map-by', 'slot:PE=4', 'ls', '-l'],
         ),
         (
             ['something'],


### PR DESCRIPTION
I ran into a problem with the `MpirunLauncher` when used with `OpenMPI`. If no binding was specified (or the default was used) **and** `cpus_per_task>1`, the resulting launch command was something like
```
mpirun -n 2 --map-by core:PE=4 executable
```
This works with Intel MPI but not with OpenMPI. Some digging (and I am not 100% sure about this) showed that it is apparently not okay to map by core when using multiple threads. Some information here: https://github.com/open-mpi/ompi/issues/7717.

To get this to work, I replace all `--map by-core:PE` calls by `--map-by slot:PE` if more than one thread is requested.