### PR TITLE
CMake Python macros: Attempt to make all activate scripts writable

### DIFF
--- a/cmake/ifsbench_python_macros.cmake
+++ b/cmake/ifsbench_python_macros.cmake
@@ -105,12 +105,16 @@ function( ifsbench_create_python_venv )
     set( Python3_FIND_VIRTUALENV STANDARD )
     find_package( Python3 ${_PAR_PYTHON_VERSION} COMPONENTS Interpreter REQUIRED )
 
-    # Ensure the activate script is writable in case the venv exists already
-    if( EXISTS "${VENV_PATH}/bin/activate" )
-        file( CHMOD "${VENV_PATH}/bin/activate" FILE_PERMISSIONS OWNER_READ OWNER_WRITE )
-    endif()
+    # Ensure the activate scripts are writable in case the venv exists already
+    file( GLOB activate_SCRIPTS "${VENV_PATH}/bin/activate*" )
+    file( GLOB Activate_SCRIPTS "${VENV_PATH}/bin/Activate*" )
+    foreach( _SCRIPT ${activate_SCRIPTS} ${Activate_SCRIPTS} )
+        if( EXISTS "${_SCRIPT}" )
+            message( STATUS "Making activate script ${_SCRIPT} writable" )
+            file( CHMOD "${_SCRIPT}" FILE_PERMISSIONS OWNER_READ OWNER_WRITE )
+        endif()
+    endforeach()
 
-    # Create a virtualenv
     # Create a virtualenv
     message( STATUS "Create Python virtual environment ${VENV_PATH}" )
     execute_process( COMMAND ${Python3_EXECUTABLE} -m venv "${VENV_PATH}" COMMAND_ERROR_IS_FATAL ANY )

--- a/ifsbench/tests/test_cmake.py
+++ b/ifsbench/tests/test_cmake.py
@@ -199,3 +199,12 @@ def test_cmake_install_and_exports(tmp_path, ifsbench_install, ecbuild_cmake_dir
             ],
             env=env,
         )
+
+
+def test_cmake_reconfigure(ifsbench_install):
+    """
+    Verify that CMake reconfiguration works (e.g., doesn't throw up errors when recreating the ifsbench venv).
+    """
+    build_dir, _ = ifsbench_install
+    result = execute(['cmake', str(build_dir)])
+    assert result.exit_code == 0, f'CMake reconfiguration failed: {result.stderr}'


### PR DESCRIPTION
### Description

When reconfiguring a CMake project, the virtual environment is re-initialized. This can fail if some activate scripts are not writable. Until now, only permissions of the default Linux activate script have been corrected, which seems to be insufficient.


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 