### PR TITLE
Exclude test modules from Sphinx documentation generation

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -17,7 +17,7 @@ help:
 .PHONY: help Makefile apidoc
 
 apidoc:
-	@$(SPHINXAPIDOC) -o "$(SOURCEDIR)" -e --no-toc -f ../ifsbench
+	@$(SPHINXAPIDOC) -o "$(SOURCEDIR)" -e --no-toc -f ../ifsbench ../ifsbench/tests ../ifsbench/*/tests
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/docs/source/_templates/autosummary/module.rst
+++ b/docs/source/_templates/autosummary/module.rst
@@ -1,0 +1,62 @@
+{{ fullname | escape | underline}}
+
+.. automodule:: {{ fullname }}
+
+   {% block attributes %}
+   {%- if attributes %}
+   .. rubric:: {{ _('Module Attributes') }}
+
+   .. autosummary::
+   {% for item in attributes %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {%- endblock %}
+
+   {%- block functions %}
+   {%- if functions %}
+   .. rubric:: {{ _('Functions') }}
+
+   .. autosummary::
+   {% for item in functions %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {%- endblock %}
+
+   {%- block classes %}
+   {%- if classes %}
+   .. rubric:: {{ _('Classes') }}
+
+   .. autosummary::
+   {% for item in classes %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {%- endblock %}
+
+   {%- block exceptions %}
+   {%- if exceptions %}
+   .. rubric:: {{ _('Exceptions') }}
+
+   .. autosummary::
+   {% for item in exceptions %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {%- endblock %}
+
+{%- block modules %}
+{%- if modules %}
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+{% for item in modules %}
+{%- if not item.startswith("test_") and item != "tests" %}
+   {{ item }}
+{%- endif %}
+{%- endfor %}
+{% endif %}
+{%- endblock %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -75,7 +75,7 @@ templates_path = ['_templates']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['**/tests/']
+exclude_patterns = ['**/tests/', '**/test_*', '**/*tests*']
 
 # Prefix each section label with the document it is in, followed by a colon
 autosectionlabel_prefix_document = True
@@ -120,3 +120,16 @@ autodoc_default_options = {
     'show-inheritance': True,  # list base classes
     'undoc-members': True,  # show also undocumented members
 }
+
+
+# -- Exclude test modules from autosummary/autodoc ---------------------------
+
+def autodoc_skip_tests(app, what, name, obj, skip, options):
+    """Skip test packages and modules during autodoc/autosummary processing."""
+    if name == 'tests' or name.startswith('test_'):
+        return True
+    return skip
+
+
+def setup(app):
+    app.connect('autodoc-skip-member', autodoc_skip_tests)


### PR DESCRIPTION

### Description

sphinx-apidoc and autosummary were both discovering and generating stubs for test packages, causing import warnings due to missing pytest. Fix by:
- Adding test directory excludes to sphinx-apidoc in the Makefile
- Broadening exclude_patterns in conf.py to cover flat-named test files
- Adding a custom autosummary template that filters test modules
- Adding an autodoc-skip-member hook as a defensive measure



### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 